### PR TITLE
[FIX JENKINS-37484] Replace FAILED with FAILURE

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help-wait.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help-wait.html
@@ -5,7 +5,7 @@
 </p>
 <dl>
     <dt><code>number</code></dt><dd>build number (integer)</dd>
-    <dt><code>result</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILED</code> (<em>may</em> be null for an ongoing build)</dd>
+    <dt><code>result</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code> (<em>may</em> be null for an ongoing build)</dd>
     <dt><code>displayName</code></dt><dd>normally <code>#123</code> but sometimes set to, e.g., an SCM commit identifier</dd>
     <dt><code>description</code></dt><dd>additional information about the build</dd>
     <dt><code>id</code></dt><dd>normally <code>number</code> as a string</dd>


### PR DESCRIPTION
Build's step documentation incorrectly describe "FAILED", instead of "FAILURE", as one of the valid build results.