### PR TITLE
Save information about child jobs in parent job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.3</version>
+            <version>2.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,5 +126,17 @@
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>1.7.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildInfoAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildInfoAction.java
@@ -6,6 +6,7 @@ import jenkins.model.Jenkins;
 import hudson.model.InvisibleAction;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -22,7 +23,11 @@ public class BuildInfoAction extends InvisibleAction {
     }
 
     public List<Run<?, ?>> getChildBuilds() {
-        List<Run<?, ?>> builds = new ArrayList<>();
+        if (buildInfos.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Run<?, ?>> builds = new ArrayList<>(buildInfos.size());
 
         for (BuildInfo buildInfo : buildInfos) {
             if (buildInfo != null) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildInfoAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildInfoAction.java
@@ -14,12 +14,15 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public class BuildInfoAction extends InvisibleAction {
     private final Queue<BuildInfo> buildInfos = new ConcurrentLinkedQueue<>();
 
+    BuildInfoAction() {
+    }
+
     BuildInfoAction(String projectName, int buildNumber) {
         buildInfos.add(new BuildInfo(projectName, buildNumber));
     }
 
-    public List<Run> getChildBuilds() {
-        List<Run> builds = new ArrayList<>();
+    public List<Run<?, ?>> getChildBuilds() {
+        List<Run<?, ?>> builds = new ArrayList<>();
 
         for (BuildInfo buildInfo : buildInfos) {
             if (buildInfo != null) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildInfoAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildInfoAction.java
@@ -1,0 +1,41 @@
+package org.jenkinsci.plugins.workflow.support.steps.build;
+
+import hudson.model.InvisibleAction;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class BuildInfoAction extends InvisibleAction {
+    private final List<BuildInfo> buildInfoList = new ArrayList<>();
+
+    public BuildInfoAction(String projectName, int buildNumber) {
+        buildInfoList.add(new BuildInfo(projectName, buildNumber));
+    }
+
+    public List<BuildInfo> getBuildInfoList() {
+        return buildInfoList;
+    }
+
+    public void addBuildInfo(String projectName, int buildNumber) {
+        buildInfoList.add(new BuildInfo(projectName, buildNumber));
+    }
+
+    static class BuildInfo {
+        private final String projectName;
+        private final int buildNumber;
+
+        public BuildInfo(String projectName, int buildNumber) {
+            this.projectName = projectName;
+            this.buildNumber = buildNumber;
+        }
+
+        public String getProjectName() {
+            return projectName;
+        }
+
+        public int getBuildNumber() {
+            return buildNumber;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
@@ -8,6 +8,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import java.util.logging.Level;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 import java.util.logging.Logger;
@@ -29,6 +30,15 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
                     TaskListener taskListener = stepContext.get(TaskListener.class);
                     // encodeTo(Run) calls getDisplayName, which does not include the project name.
                     taskListener.getLogger().println("Starting building: " + ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName()));
+                    FlowNode parentNode = stepContext.get(FlowNode.class);
+                    if (parentNode != null) {
+                        BuildInfoAction buildInfoAction = parentNode.getAction(BuildInfoAction.class);
+                        if (buildInfoAction == null) {
+                            parentNode.addAction(new BuildInfoAction(run.getParent().getFullName(), run.getNumber()));
+                        } else {
+                            buildInfoAction.addBuildInfo(run.getParent().getFullName(), run.getNumber());
+                        }
+                    }
                 } catch (Exception e) {
                     LOGGER.log(WARNING, null, e);
                 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildInfoActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildInfoActionTest.java
@@ -1,0 +1,81 @@
+package org.jenkinsci.plugins.workflow.support.steps.build;
+
+import hudson.model.Job;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Jenkins.class)
+public class BuildInfoActionTest {
+    private Jenkins jenkins;
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(Jenkins.class);
+        jenkins = PowerMockito.mock(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        PowerMockito.when(Jenkins.getActiveInstance()).thenReturn(jenkins);
+    }
+
+    @Test
+    public void testConcurrentAccess() throws Exception {
+        Job item = Mockito.mock(Job.class);
+        when(jenkins.getItemByFullName(any(String.class), same(Job.class))).thenReturn(item);
+
+        BuildInfoAction buildInfoAction = new BuildInfoAction("firstOne", 1);
+
+        ExecutorService executors = Executors.newFixedThreadPool(5);
+        Runnable task1 = createRunnable("A", buildInfoAction);
+        Runnable task2 = createRunnable("B", buildInfoAction);
+        Runnable task3 = createRunnable("C", buildInfoAction);
+        Runnable task4 = createRunnable("D", buildInfoAction);
+        Runnable task5 = createRunnable("E", buildInfoAction);
+
+        Future future1 = executors.submit(task1);
+        Future future2 = executors.submit(task2);
+        Future future3 = executors.submit(task3);
+        Future future4 = executors.submit(task4);
+        Future future5 = executors.submit(task5);
+
+        while (true) {
+            if (future1.isDone() && future2.isDone() && future3.isDone() && future4.isDone() && future5.isDone() ) {
+                break;
+            }
+
+            Thread.sleep(100);
+        }
+
+        assertEquals(501, buildInfoAction.getChildBuilds().size());
+    }
+
+    private Runnable createRunnable(final String name, final BuildInfoAction action) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                for (int i = 0; i < 100; i++) {
+                    action.addBuildInfo(name, i + 1);
+                    try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException ignored) {
+                    }
+                }
+            }
+        };
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -13,6 +13,7 @@ import hudson.model.Label;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
 import hudson.model.Result;
+import hudson.model.Run;
 import hudson.model.StringParameterDefinition;
 import hudson.model.TaskListener;
 import hudson.model.queue.QueueTaskFuture;
@@ -73,11 +74,12 @@ public class BuildTriggerStepTest {
             "echo \"ds.result=${ds.result} ds.number=${ds.number}\"", true));
         WorkflowRun usRun = j.buildAndAssertSuccess(us);
         j.assertLogContains("ds.result=SUCCESS ds.number=1", usRun);
+        assertBuildInfoAction(usRun, "ds", 1);
+
         // TODO JENKINS-28673 assert no warnings, as in StartupTest.noWarnings
         // (but first need to deal with `WARNING: Failed to instantiate optional component org.jenkinsci.plugins.workflow.steps.scm.SubversionStep$DescriptorImpl; skipping`)
         ds.getBuildByNumber(1).delete();
 
-        assertBuildInfoAction(usRun, "ds", 1);
     }
 
     @Issue("JENKINS-25851")
@@ -446,8 +448,8 @@ public class BuildTriggerStepTest {
         for(FlowNode step : walker) {
             BuildInfoAction buildInfoAction = step.getAction(BuildInfoAction.class);
             if (buildInfoAction != null) {
-                for (BuildInfoAction.BuildInfo buildInfo : buildInfoAction.getBuildInfoList()) {
-                    if (buildInfo.getBuildNumber() == buildNumber && buildInfo.getProjectName().equals(projectName)) {
+                for (Run child : buildInfoAction.getChildBuilds()) {
+                    if (child.getNumber() == buildNumber && child.getParent().getFullName().equals(projectName)) {
                         return;
                     }
                 }


### PR DESCRIPTION
In some cases it would  be nice to know what exactly was triggered by pipeline job. I.e. this information can be used by Build Failure Analyzer Plugin to show failures in child jobs on the top trigger job.