### PR TITLE
Minor updates for better PCT compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.1</version>
+        <version>3.2</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -40,8 +40,9 @@
     <properties>
         <jenkins.version>2.32.2</jenkins.version>
         <java.level>7</java.level>
-        <scm-api.version>2.0.8</scm-api.version>
+        <scm-api.version>2.2.6</scm-api.version>
         <workflow-step-api-plugin.version>2.14</workflow-step-api-plugin.version>
+        <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -57,7 +58,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
+            <version>${workflow-support-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -80,7 +81,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
+            <version>${workflow-support-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -130,7 +131,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.4</version>
+            <version>2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -34,6 +34,7 @@ import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMHeadEvent;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.impl.mock.MockSCMController;
+import jenkins.scm.impl.mock.MockSCMDiscoverBranches;
 import jenkins.scm.impl.mock.MockSCMNavigator;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
 import org.apache.commons.lang.StringUtils;
@@ -418,16 +419,15 @@ public class BuildTriggerStepTest {
         j.assertBuildStatusSuccess(j.waitForCompletion(us1));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     @Issue("JENKINS-38887")
     public void triggerOrgFolder() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             c.createRepository("foo");
             WorkflowJob us = j.jenkins.createProject(WorkflowJob.class, "us");
-            us.setDefinition(new CpsFlowDefinition("build job:'ds', wait:false"));
+            us.setDefinition(new CpsFlowDefinition("build job:'ds', wait:false", true));
             OrganizationFolder ds = j.jenkins.createProject(OrganizationFolder.class, "ds");
-            ds.getSCMNavigators().add(new MockSCMNavigator(c, true, false, false));
+            ds.getSCMNavigators().add(new MockSCMNavigator(c, new MockSCMDiscoverBranches()));
             ds.getProjectFactories().add(new DummyMultiBranchProjectFactory());
             j.waitUntilNoActivity();
             assertThat(ds.getComputation().getResult(), nullValue());


### PR DESCRIPTION
Otherwise you get

```
java.lang.NoSuchMethodError: jenkins.scm.impl.mock.MockSCMController.createRepository(Ljava/lang/String;)V
	at org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStepTest.triggerOrgFolder(BuildTriggerStepTest.java:391)
```

due to incompatible changes in `scm-api` tests.

@reviewbybees