### PR TITLE
Add link to failure message in console

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
@@ -49,7 +49,7 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
                     trigger.context.onFailure(trigger.interruption);
                 }
             } else {
-                trigger.context.onFailure(new AbortException(run.getFullDisplayName() + " completed with status " + run.getResult() + " (propagate: false to ignore)"));
+                trigger.context.onFailure(new AbortException(ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName()) + " completed with status " + run.getResult() + " (propagate: false to ignore)"));
             }
         }
         run.getActions().removeAll(run.getActions(BuildTriggerAction.class));


### PR DESCRIPTION
Turns:
<img width="638" alt="screenshot 2018-11-16 at 16 44 08" src="https://user-images.githubusercontent.com/2519238/48635021-e5026e80-e9be-11e8-9cb1-2cc479763caa.png">

Into:
<img width="636" alt="screenshot 2018-11-16 at 16 44 16" src="https://user-images.githubusercontent.com/2519238/48635023-e764c880-e9be-11e8-8a95-1a25caf6e86e.png">

Reasoning: Right now you have to look for the link in the whole console. This change adds a link to the failed job directly in the error message.