### PR TITLE
[JENKINS-49073] Propagate the downstream result, not just FAILURE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.33</version>
+        <version>3.43</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
@@ -50,7 +50,8 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
                     trigger.context.onFailure(trigger.interruption);
                 }
             } else {
-                trigger.context.onFailure(new FlowInterruptedException(run.getResult(), new DownstreamFailureCause(run)));
+                Result result = run.getResult();
+                trigger.context.onFailure(new FlowInterruptedException(result != null ? result : /* probably impossible */ Result.FAILURE, new DownstreamFailureCause(run)));
             }
         }
         run.getActions().removeAll(run.getActions(BuildTriggerAction.class));

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
@@ -11,6 +11,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import jenkins.util.Timer;
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 @Extension
@@ -49,7 +50,7 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
                     trigger.context.onFailure(trigger.interruption);
                 }
             } else {
-                trigger.context.onFailure(new AbortException(run.getFullDisplayName() + " completed with status " + run.getResult() + " (propagate: false to ignore)"));
+                trigger.context.onFailure(new FlowInterruptedException(run.getResult(), new DownstreamFailureCause(run)));
             }
         }
         run.getActions().removeAll(run.getActions(BuildTriggerAction.class));

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/DownstreamFailureCause.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/DownstreamFailureCause.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.steps.build;
+
+import hudson.model.Run;
+import javax.annotation.CheckForNull;
+import jenkins.model.CauseOfInterruption;
+
+/**
+ * Indicates that an upstream build failed because of a downstream build’s status.
+ */
+public final class DownstreamFailureCause extends CauseOfInterruption {
+
+    private static final long serialVersionUID = 1;
+
+    private final String id;
+
+    DownstreamFailureCause(Run<?, ?> downstream) {
+        id = downstream.getExternalizableId();
+    }
+
+    public @CheckForNull Run<?, ?> getDownstreamBuild() {
+        return Run.fromExternalizableId(id);
+    }
+
+    @Override public String getShortDescription() {
+        Run<?, ?> downstream = getDownstreamBuild();
+        if (downstream != null) {
+            return downstream.getFullDisplayName() + " completed with status " + downstream.getResult() + " (propagate: false to ignore)";
+        } else {
+            return "Downstream build was not stable (propagate: false to ignore)";
+        }
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/DownstreamFailureCause/summary.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/DownstreamFailureCause/summary.jelly
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2019 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    <j:set var="ds" value="${it.downstreamBuild}"/>
+    <j:choose>
+        <j:when test="${ds != null}">
+            <a class="model-link inside" href="${rootURL}/${ds.url}">${ds.fullDisplayName}</a> was not stable
+        </j:when>
+        <j:otherwise>
+            <j:out value="${it.shortDescription}"/>
+        </j:otherwise>
+    </j:choose>
+</j:jelly>


### PR DESCRIPTION
[JENKINS-49073](https://issues.jenkins-ci.org/browse/JENKINS-49073)

![screenshot](https://user-images.githubusercontent.com/154109/58816104-ca0fe880-85f6-11e9-9fde-f37975db9361.png)

Probably improved by https://github.com/jenkinsci/workflow-step-api-plugin/pull/44.

Note that this may also satisfy the stated use case for #13:

> this information can be used by Build Failure Analyzer Plugin to show failures in child jobs on the top trigger job