### PR TITLE
Migrate snippet generator tests from workflow-cps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <scm-api.version>2.2.7</scm-api.version>
         <workflow-step-api-plugin.version>2.18</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>3.1</workflow-support-plugin.version>
+        <workflow-cps-plugin.version>2.62</workflow-cps-plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -88,7 +89,14 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.62</version>
+            <version>${workflow-cps-plugin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>${workflow-cps-plugin.version}</version>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
@@ -86,39 +86,6 @@ public class BuildTriggerStep extends AbstractStepImpl {
             super(BuildTriggerStepExecution.class);
         }
 
-        @Override public Step newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            BuildTriggerStep step = (BuildTriggerStep) super.newInstance(req, formData);
-            // Cf. ParametersDefinitionProperty._doBuild:
-            Object parameter = formData.get("parameter");
-            JSONArray params = parameter != null ? JSONArray.fromObject(parameter) : null;
-            if (params != null) {
-                Job<?,?> context = StaplerReferer.findItemFromRequest(Job.class);
-                Job<?,?> job = Jenkins.getActiveInstance().getItem(step.getJob(), context, Job.class);
-                if (job != null) {
-                    ParametersDefinitionProperty pdp = job.getProperty(ParametersDefinitionProperty.class);
-                    if (pdp != null) {
-                        List<ParameterValue> values = new ArrayList<ParameterValue>();
-                        for (Object o : params) {
-                            JSONObject jo = (JSONObject) o;
-                            String name = jo.getString("name");
-                            ParameterDefinition d = pdp.getParameterDefinition(name);
-                            if (d == null) {
-                                throw new IllegalArgumentException("No such parameter definition: " + name);
-                            }
-                            ParameterValue parameterValue = d.createValue(req, jo);
-                            if (parameterValue != null) {
-                                values.add(parameterValue);
-                            } else {
-                                throw new IllegalArgumentException("Cannot retrieve the parameter value: " + name);
-                            }
-                        }
-                        step.setParameters(values);
-                    }
-                }
-            }
-            return step;
-        }
-
         @Override
         public String getFunctionName() {
             return "build";

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
@@ -88,8 +88,7 @@ public class BuildTriggerStep extends AbstractStepImpl {
 
         // Note: This is necessary because the JSON format of the parameters produced by config.jelly when
         // using the snippet generator does not match what would be neccessary for databinding to work automatically.
-        // For non-snippet generator use, this is unnecessary. Somewhat surprisingly,
-        // `SnippetizerTester.assertRoundTrip(BuildTriggerStep.class)` does not actually test this behavior.
+        // For non-snippet generator use, this is unnecessary.
         @Override public Step newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             BuildTriggerStep step = (BuildTriggerStep) super.newInstance(req, formData);
             // Cf. ParametersDefinitionProperty._doBuild:

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -590,4 +590,9 @@ public class BuildTriggerStepTest {
         FreeStyleProject us = j.jenkins.createProject(FreeStyleProject.class, "us0");
         st.assertGenerateSnippet("{'stapler-class':'" + BuildTriggerStep.class.getName() + "', 'job':'ds0'}", "build 'ds0'", us.getAbsoluteUrl() + "configure");
     }
+
+    @Test
+    public void buildStepDocs() throws Exception {
+        SnippetizerTester.assertDocGeneration(BuildTriggerStep.class);
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -554,15 +554,12 @@ public class BuildTriggerStepTest {
                 j.assertBuildStatus(Result.FAILURE, us.scheduleBuild2(0)));
     }
 
-    @Test public void buildTriggerStep() throws Exception {
+    @Test public void snippetizer() throws Exception {
         SnippetizerTester st = new SnippetizerTester(j);
         BuildTriggerStep step = new BuildTriggerStep("downstream");
         st.assertRoundTrip(step, "build 'downstream'");
         step.setParameters(Arrays.asList(new StringParameterValue("branch", "default"), new BooleanParameterValue("correct", true)));
-        if (StringParameterDefinition.DescriptorImpl.class.isAnnotationPresent(Symbol.class)) {
-            st.assertRoundTrip(step, "build job: 'downstream', parameters: [string(name: 'branch', value: 'default'), booleanParam(name: 'correct', value: true)]");
-        } else { // TODO 2.x delete
-            st.assertRoundTrip(step, "build job: 'downstream', parameters: [[$class: 'StringParameterValue', name: 'branch', value: 'default'], [$class: 'BooleanParameterValue', name: 'correct', value: true]]");
-        }
+        // Note: This does not actually test the format of the JSON produced by the snippet generator for parameters.
+        st.assertRoundTrip(step, "build job: 'downstream', parameters: [string(name: 'branch', value: 'default'), booleanParam(name: 'correct', value: true)]");
     }
 }


### PR DESCRIPTION
It looks like tests pass and the snippet generator works correctly even without this override, so I'm not sure what it's for. If it turns out it is necessary, I'd like to add a test and/comment explaining what it is here for.

EDIT: In the end, just migrating some tests from workflow-cps, see https://github.com/jenkinsci/workflow-cps-plugin/pull/304.