### PR TITLE
Remove usages of deprecated APIs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
@@ -96,7 +96,7 @@ public class BuildTriggerStep extends AbstractStepImpl {
             JSONArray params = parameter != null ? JSONArray.fromObject(parameter) : null;
             if (params != null) {
                 Job<?,?> context = StaplerReferer.findItemFromRequest(Job.class);
-                Job<?,?> job = Jenkins.getActiveInstance().getItem(step.getJob(), context, Job.class);
+                Job<?,?> job = Jenkins.get().getItem(step.getJob(), context, Job.class);
                 if (job != null) {
                     ParametersDefinitionProperty pdp = job.getProperty(ParametersDefinitionProperty.class);
                     if (pdp != null) {
@@ -206,7 +206,7 @@ public class BuildTriggerStep extends AbstractStepImpl {
             if (!value) {
                 return FormValidation.ok();
             }
-            Item item = Jenkins.getActiveInstance().getItem(job, context, Item.class);
+            Item item = Jenkins.get().getItem(job, context, Item.class);
             if (item == null) {
                 return FormValidation.ok();
             }
@@ -220,7 +220,7 @@ public class BuildTriggerStep extends AbstractStepImpl {
             if (StringUtils.isBlank(value)) {
                 return FormValidation.warning(Messages.BuildTriggerStep_no_job_configured());
             }
-            Item item = Jenkins.getActiveInstance().getItem(value, context, Item.class);
+            Item item = Jenkins.get().getItem(value, context, Item.class);
             if (item == null) {
                 return FormValidation.error(Messages.BuildTriggerStep_cannot_find(value));
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
@@ -173,12 +173,12 @@ public class BuildTriggerStep extends AbstractStepImpl {
                 }
             }
 
-            if (container == null || container == Jenkins.getInstance()) {
-                new Visitor("").onItemGroup(Jenkins.getInstance());
+            if (container == null || container == Jenkins.getInstanceOrNull()) {
+                new Visitor("").onItemGroup(Jenkins.getInstanceOrNull());
             } else {
                 new Visitor("").onItemGroup(container);
                 if (value.startsWith("/"))
-                    new Visitor("/").onItemGroup(Jenkins.getInstance());
+                    new Visitor("/").onItemGroup(Jenkins.getInstanceOrNull());
 
                 for (StringBuilder p = new StringBuilder("../"); value.startsWith(p.toString()); p .append("../")) {
                     container = ((Item) container).getParent();

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.workflow.support.steps.build;
 
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.console.ModelHyperlinkNote;
 import hudson.model.Action;
@@ -183,11 +182,10 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
         return Lists.newArrayList(allParameters.values());
     }
 
-    @SuppressFBWarnings(value="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification="TODO 1.653+ switch to Jenkins.getInstanceOrNull")
     @Override
     public void stop(Throwable cause) throws Exception {
         StepContext context = getContext();
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins == null) {
             context.onFailure(cause);
             return;

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -59,7 +59,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
     @Override
     public boolean start() throws Exception {
         String job = step.getJob();
-        Item item = Jenkins.getActiveInstance().getItem(job, invokingRun.getParent(), Item.class);
+        Item item = Jenkins.get().getItem(job, invokingRun.getParent(), Item.class);
         if (item == null) {
             throw new AbortException("No item named " + job + " found");
         }
@@ -131,9 +131,9 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
                 }
             }
             if (quietPeriod == null) {
-                quietPeriod = Jenkins.getActiveInstance().getQuietPeriod();
+                quietPeriod = Jenkins.get().getQuietPeriod();
             }
-            ScheduleResult scheduleResult = Jenkins.getActiveInstance().getQueue().schedule2(task, quietPeriod,actions);
+            ScheduleResult scheduleResult = Jenkins.get().getQueue().schedule2(task, quietPeriod,actions);
             if (scheduleResult.isRefused()) {
                 throw new AbortException("Failed to trigger build of " + item.getFullName());
             }
@@ -254,7 +254,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
                 }
             }
         }
-        for (Computer c : Jenkins.getActiveInstance().getComputers()) {
+        for (Computer c : Jenkins.get().getComputers()) {
             for (Executor e : c.getExecutors()) {
                 String r = running(e);
                 if (r != null) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -486,7 +486,7 @@ public class BuildTriggerStepTest {
         WorkflowJob ds = j.jenkins.createProject(WorkflowJob.class, "ds");
         ds.setDefinition(new CpsFlowDefinition("", true));
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
-        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new MockQueueItemAuthenticator(Collections.singletonMap("us", User.get("dev").impersonate())));
+        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new MockQueueItemAuthenticator(Collections.singletonMap("us", User.getById("dev", true).impersonate())));
         // Control case: dev can do anything to ds.
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.ADMINISTER).everywhere().to("dev"));
         j.buildAndAssertSuccess(us);


### PR DESCRIPTION
While perusing the source tree, I noticed a number of deprecated methods:

- The documentation for [`User.get(java.lang.String)`](https://javadoc.jenkins-ci.org/hudson/model/User.html#get-java.lang.String-) states: "This method is deprecated, because it causes unexpected `User` creation by API usage code and causes performance degradation of used to retrieve users by ID. Use [`getById(java.lang.String, boolean)`](https://javadoc.jenkins-ci.org/hudson/model/User.html#getById-java.lang.String-boolean-) when you know you have an ID."
- The documentation for [`Jenkins.getActiveInstance()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getActiveInstance--) states: "This is a verbose historical alias for [`get()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#get--)."
- The documentation for [`Jenkins.getInstance()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstance--) states: "This is a historical alias for [`getInstanceOrNull()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstanceOrNull--) but with ambiguous nullability. Use [`get()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#get--) in typical cases."

Accordingly, I replaced any calls to `User.get(java.lang.String` with calls to `User.getById(java.lang.String, boolean`, I replaced any calls to `Jenkins.getActiveInstance()` with calls to `Jenkins.get()`, and I replaced any calls to `Jenkins.getInstance()` with calls to `Jenkins.getInstanceOrNull()`.