### PR TITLE
Use Actionable.removeActions

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
@@ -39,7 +39,6 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
     }
 
     @Override
-    @SuppressWarnings("deprecation") // TODO 2.30+ use removeAction
     public void onCompleted(Run<?,?> run, @Nonnull TaskListener listener) {
         for (BuildTriggerAction.Trigger trigger : BuildTriggerAction.triggersFor(run)) {
             LOGGER.log(Level.FINE, "completing {0} for {1}", new Object[] {run, trigger.context});
@@ -54,7 +53,7 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
                 trigger.context.onFailure(new FlowInterruptedException(result != null ? result : /* probably impossible */ Result.FAILURE, new DownstreamFailureCause(run)));
             }
         }
-        run.getActions().removeAll(run.getActions(BuildTriggerAction.class));
+        run.removeActions(BuildTriggerAction.class);
     }
 
     @Override


### PR DESCRIPTION
In c869245 a TODO was added to use `removeAction` once the baseline was updated to a version with support for [JENKINS-39404](https://issues.jenkins-ci.org/browse/JENKINS-39404). That fix was released in 2.30 and the baseline is now 2.121.1, so this TODO can be completed.

I verified that this code was exercised in `BuildTriggerStepTest#triggerWorkflow`.