### PR TITLE
Use ParameterizedJobMixIn.scheduleBuild2 convenience method

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -90,18 +90,11 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
                 parameters = completeDefaultParameters(parameters, (Job) project);
                 actions.add(new ParametersAction(parameters));
             }
-            Integer quietPeriod = step.getQuietPeriod();
-            // TODO use new convenience method in 1.621
-            if (quietPeriod == null) {
-                quietPeriod = project.getQuietPeriod();
-            }
-            QueueTaskFuture<?> f = new ParameterizedJobMixIn() {
-                @Override
-                protected Job asJob() {
-                    return (Job) project;
-                }
-            }.scheduleBuild2(quietPeriod, actions.toArray(new Action[actions.size()]));
-            if (f == null) {
+            int quietPeriod = step.getQuietPeriod() != null ? step.getQuietPeriod().intValue() : -1;
+            Queue.Item queueItem =
+                    ParameterizedJobMixIn.scheduleBuild2(
+                            (Job<?, ?>) project, quietPeriod, actions.toArray(new Action[actions.size()]));
+            if (queueItem == null || queueItem.getFuture() == null) {
                 throw new AbortException("Failed to trigger build of " + project.getFullName());
             }
         } else if (item instanceof Queue.Task){


### PR DESCRIPTION
In d5eb973, a TODO was added noting that the `ParameterizedJobMixIn.scheduleBuild2` convenience method introduced in jenkinsci/jenkins#1771 should be used once the baseline was 1.621 or higher. The baseline is now 2.121.1, so this TODO can be completed.

I verified that this code was exercised in `BuildTriggerStepTest#triggerWorkflow`.