### PR TITLE
Test propagation of additional downstream result types

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help-propagate.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help-propagate.html
@@ -1,5 +1,6 @@
 <p>
-    If enabled (default state), then if the downstream build is anything but successful (blue ball), this step fails.
+    If enabled (default state), then the result of this step is that of the downstream build (e.g.,
+    success, unstable, failure, not built, or aborted).
     If disabled, then this step succeeds even if the downstream build is unstable, failed, etc.;
     use the <code>result</code> property of the return value as needed.
 </p>


### PR DESCRIPTION
#24 changed the behavior of this plugin to propagate the result of downstream builds. However, only propagation of unstable builds was covered in unit tests, and the documentation was not updated. This PR adds test coverage for the other types of downstream statuses and updates the documentation.