### PR TITLE
[JENKINS-60216] Make the build step automatically convert some kinds of parameter mismatches

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -183,7 +183,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
                             ParameterValue pv = allParameters.get(pDef.getName());
                             if (pv instanceof StringParameterValue) {
                                 String pDefDisplayName = pDef.getDescriptor().getDisplayName();
-                                listener.getLogger().println(String.format("The parameter '%s' did not have the type expected by %s. Converting to %s.", pv.getName(), project.getFullName(), pDefDisplayName));
+                                listener.getLogger().println(String.format("The parameter '%s' did not have the type expected by %s. Converting to %s.", pv.getName(), ModelHyperlinkNote.encodeTo(project), pDefDisplayName));
                                 ParameterValue convertedValue = ((SimpleParameterDefinition) pDef).createValue((String) pv.getValue());
                                 allParameters.put(pDef.getName(), convertedValue);
                                 description = Messages.BuildTriggerStepExecution_convertedParameterDescription(description, pDefDisplayName, invokingRun.toString());

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/Messages.properties
@@ -28,3 +28,5 @@ BuildTriggerStep.no_job_configured=No job configured
 BuildTriggerStep.cannot_find=No such job {0}
 BuildTriggerStep.unsupported=Building a {0} is not supported
 BuildTriggerStepExecution.building_=Building {0}
+BuildTriggerStepExecution.convertedParameterDescription=\
+    {0} (Automatically converted to {1} because {2} passed the parameter using a different type)


### PR DESCRIPTION
See [JENKINS-60216](https://issues.jenkins-ci.org/browse/JENKINS-60216). Subsumes #34. 

Tries to keep the behavior as similar to https://github.com/jenkinsci/parameterized-trigger-plugin/pull/62 as possible, since that behavior has been around for a long time so it seems unlikely to be problematic (there was a [followup commit](https://github.com/jenkinsci/parameterized-trigger-plugin/commit/8f410be6a8a203e92c4120a12750514878585869) for some issues, but from reading the PR and associated tickets, it seems that case only applied to Choice Parameters, which are already special-cased here and will not be converted by this PR).

I'll create a JIRA ticket for this tomorrow for tracking.

@Wadeck: I added you as a co-author to the commit because it is based on a squashed version of your PR, but let me know if you want me to remove you as a co-author and I will do that.

Open questions:

* [ ] Should we add a system property to enable/disable this behavior?