### PR TITLE
JENKINS-60345: Add trigger build link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.31</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <version>${workflow-support-plugin.version}</version>
         </dependency>
@@ -99,12 +104,6 @@
             <artifactId>workflow-cps</artifactId>
             <version>${workflow-cps-plugin.version}</version>
             <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <version>2.31</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep.java
@@ -1,0 +1,225 @@
+package org.jenkinsci.plugins.workflow.support.steps.build;
+
+import hudson.Extension;
+import hudson.model.AutoCompletionCandidates;
+import hudson.model.Describable;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.ItemVisitor;
+import hudson.model.Job;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Queue;
+import hudson.model.Run;
+import hudson.util.FormValidation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import jenkins.model.Jenkins;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.util.StaplerReferer;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * Pipeline step that adds an link to the build's page that allows the
+ * user to start a downstream build with predefined parameters.
+ */
+public class AddTriggerBuildLinkStep extends Step implements Serializable {
+
+    private final String job;
+    private final String linkLabel;
+    private final String linkTooltip;
+    private List<ParameterValue> parameters;
+
+    @DataBoundConstructor
+    public AddTriggerBuildLinkStep(String job, final String linkLabel, final String linkTooltip) {
+        this.job = job;
+        this.linkTooltip = linkTooltip;
+        this.linkLabel = linkLabel;
+    }
+
+    public String getJob() {
+        return this.job;
+    }
+    
+    public String getLinkTooltip() {
+        return this.linkTooltip;
+    }
+    
+    public String getLinkLabel() {
+        return this.linkLabel;
+    }
+
+    public List<ParameterValue> getParameters() {
+        return this.parameters;
+    }
+
+    @DataBoundSetter 
+    public void setParameters(List<ParameterValue> parameters) {
+        this.parameters = parameters;
+    }
+    
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new AddTriggerBuildLinkStepExecution(context, this);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        public DescriptorImpl() {
+            super();
+        }
+
+        // Note: This is necessary because the JSON format of the parameters produced by config.jelly when
+        // using the snippet generator does not match what would be neccessary for databinding to work automatically.
+        // For non-snippet generator use, this is unnecessary.
+        @Override 
+        public Step newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            AddTriggerBuildLinkStep step = (AddTriggerBuildLinkStep) super.newInstance(req, formData);
+            // Cf. ParametersDefinitionProperty._doBuild:
+            Object parameter = formData.get("parameter");
+            JSONArray params = parameter != null ? JSONArray.fromObject(parameter) : null;
+            if (params != null) {
+                Job<?,?> context = StaplerReferer.findItemFromRequest(Job.class);
+                Job<?,?> job = Jenkins.get().getItem(step.getJob(), context, Job.class);
+                if (job != null) {
+                    ParametersDefinitionProperty pdp = job.getProperty(ParametersDefinitionProperty.class);
+                    if (pdp != null) {
+                        List<ParameterValue> values = new ArrayList<ParameterValue>();
+                        for (Object o : params) {
+                            JSONObject jo = (JSONObject) o;
+                            String name = jo.getString("name");
+                            ParameterDefinition d = pdp.getParameterDefinition(name);
+                            if (d == null) {
+                                throw new IllegalArgumentException("No such parameter definition: " + name);
+                            }
+                            ParameterValue parameterValue = d.createValue(req, jo);
+                            if (parameterValue != null) {
+                                values.add(parameterValue);
+                            } else {
+                                throw new IllegalArgumentException("Cannot retrieve the parameter value: " + name);
+                            }
+                        }
+                        step.setParameters(values);
+                    }
+                }
+            }
+            return step;
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "addTriggerBuildLink";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Add a link to build page to trigger a downstream build";
+        }
+
+        public AutoCompletionCandidates doAutoCompleteJob(@AncestorInPath ItemGroup<?> container, @QueryParameter final String value) {
+            // TODO remove code copy&pasted from AutoCompletionCandidates.ofJobNames when it supports testing outside Item bound
+            final AutoCompletionCandidates candidates = new AutoCompletionCandidates();
+            class Visitor extends ItemVisitor {
+                String prefix;
+
+                Visitor(String prefix) {
+                    this.prefix = prefix;
+                }
+
+                @Override
+                public void onItem(Item i) {
+                    String n = contextualNameOf(i);
+                    if ((n.startsWith(value) || value.startsWith(n))
+                            // 'foobar' is a valid candidate if the current value is 'foo'.
+                            // Also, we need to visit 'foo' if the current value is 'foo/bar'
+                            && (value.length() > n.length() || !n.substring(value.length()).contains("/"))
+                            // but 'foobar/zot' isn't if the current value is 'foo'
+                            // we'll first show 'foobar' and then wait for the user to type '/' to show the rest
+                            && i.hasPermission(Item.READ)
+                        // and read permission required
+                            ) {
+                        if (i instanceof Queue.Task && n.startsWith(value))
+                            candidates.add(n);
+
+                        // recurse
+                        String oldPrefix = prefix;
+                        prefix = n;
+                        super.onItem(i);
+                        prefix = oldPrefix;
+                    }
+                }
+
+                private String contextualNameOf(Item i) {
+                    if (prefix.endsWith("/") || prefix.length() == 0)
+                        return prefix + i.getName();
+                    else
+                        return prefix + '/' + i.getName();
+                }
+            }
+
+            if (container == null || container == Jenkins.get()) {
+                new Visitor("").onItemGroup(Jenkins.get());
+            } else {
+                new Visitor("").onItemGroup(container);
+                if (value.startsWith("/"))
+                    new Visitor("/").onItemGroup(Jenkins.get());
+
+                for (StringBuilder p = new StringBuilder("../"); value.startsWith(p.toString()); p .append("../")) {
+                    container = ((Item) container).getParent();
+                    new Visitor(p.toString()).onItemGroup(container);
+                }
+            }
+            return candidates;
+            // END of copy&paste
+        }
+
+        @Restricted(DoNotUse.class) // for use from config.jelly
+        public String getContext() {
+            Job<?,?> job = StaplerReferer.findItemFromRequest(Job.class);
+            return job != null ? job.getFullName() : null;
+        }
+
+        public FormValidation doCheckJob(@AncestorInPath ItemGroup<?> context, @QueryParameter String value) {
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.warning(Messages.BuildTriggerStep_no_job_configured());
+            }
+            Item item = Jenkins.get().getItem(value, context, Item.class);
+            if (item == null) {
+                return FormValidation.error(Messages.BuildTriggerStep_cannot_find(value));
+            }
+            if (item instanceof Queue.Task) {
+                return FormValidation.ok();
+            }
+            if (item instanceof Describable) {
+                return FormValidation.error(Messages.BuildTriggerStep_unsupported(((Describable) item).getDescriptor().getDisplayName()));
+            }
+            return FormValidation.error(Messages.BuildTriggerStep_unsupported(item.getClass().getName()));
+        }
+        
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            final Set<Class<?>> result = new LinkedHashSet<>();
+            result.add(Run.class);
+            return result;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStepExecution.java
@@ -1,0 +1,90 @@
+package org.jenkinsci.plugins.workflow.support.steps.build;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.List;
+
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+
+import hudson.AbortException;
+import hudson.model.Describable;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.ParameterValue;
+import hudson.model.Queue;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+import jenkins.model.ParameterizedJobMixIn;
+
+/**
+ * Execution for the {@link AddTriggerBuildLinkStep}.
+ */
+public class AddTriggerBuildLinkStepExecution extends StepExecution {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient Run<?,?> invokingRun;
+    private transient FlowNode node;
+    private transient PrintStream logger;
+
+    private final AddTriggerBuildLinkStep step;
+
+
+    public AddTriggerBuildLinkStepExecution(
+            final StepContext context,
+            final AddTriggerBuildLinkStep step) throws IOException, InterruptedException {
+        super(context);
+        this.invokingRun = context.get(Run.class);
+        this.node = context.get(FlowNode.class);
+        this.logger = context.get(TaskListener.class).getLogger();
+        this.step = step;
+    }
+
+    @SuppressWarnings({"rawtypes"}) // cannot get from ParameterizedJob back to ParameterizedJobMixIn trivially
+    @Override
+    public boolean start() throws Exception {
+        final String job = this.step.getJob();
+        final Item item = Jenkins.get().getItem(job, this.invokingRun.getParent(), Item.class);
+        if (item == null) {
+            throw new AbortException("No item named " + job + " found");
+        }
+        item.checkPermission(Item.BUILD);
+
+        List<ParameterValue> parameters = this.step.getParameters();
+        if (item instanceof ParameterizedJobMixIn.ParameterizedJob) {
+            final ParameterizedJobMixIn.ParameterizedJob project = (ParameterizedJobMixIn.ParameterizedJob) item;
+
+            if (parameters != null) {
+                parameters = BuildTriggerStepExecution.completeDefaultParameters(parameters, (Job) project, invokingRun, logger);
+            }
+
+        } else if (item instanceof Queue.Task){
+            if (this.step.getParameters() != null && !this.step.getParameters().isEmpty()) {
+                throw new AbortException("Item type does not support parameters");
+            }
+
+        } else {
+            throw new AbortException("The item named " + job + " is a "
+                    + (item instanceof Describable
+                    ? ((Describable) item).getDescriptor().getDisplayName()
+                    : item.getClass().getName())
+                    + " which is not something that can be built");
+        }
+
+        final TriggerBuildLinkAction buttonAction = new TriggerBuildLinkAction(
+            this.invokingRun,
+            this.step.getJob(),
+            this.step.getLinkLabel(),
+            this.step.getLinkTooltip(),
+            parameters,
+            this.node
+        );
+
+        this.invokingRun.addAction(buttonAction);
+        this.getContext().onSuccess(null);
+        return true;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -38,6 +38,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -90,7 +91,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
 
             List<ParameterValue> parameters = step.getParameters();
             if (parameters != null) {
-                parameters = completeDefaultParameters(parameters, (Job) project);
+                parameters = completeDefaultParameters(parameters, (Job) project, invokingRun, listener.getLogger());
                 actions.add(new ParametersAction(parameters));
             }
             int quietPeriod = step.getQuietPeriod() != null ? step.getQuietPeriod().intValue() : -1;
@@ -148,7 +149,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
         }
     }
 
-    private List<ParameterValue> completeDefaultParameters(List<ParameterValue> parameters, Job<?,?> project) throws AbortException {
+    static List<ParameterValue> completeDefaultParameters(List<ParameterValue> parameters, Job<?,?> project, Run<?, ?> invokingRun, PrintStream logger) throws AbortException {
         Map<String,ParameterValue> allParameters = new HashMap<>();
         for (ParameterValue pv : parameters) {
             allParameters.put(pv.getName(), pv);
@@ -175,7 +176,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
                             ParameterValue pv = allParameters.get(pDef.getName());
                             if (pv instanceof StringParameterValue) {
                                 String pDefDisplayName = pDef.getDescriptor().getDisplayName();
-                                listener.getLogger().println(String.format("The parameter '%s' did not have the type expected by %s. Converting to %s.", pv.getName(), ModelHyperlinkNote.encodeTo(project), pDefDisplayName));
+                                logger.println(String.format("The parameter '%s' did not have the type expected by %s. Converting to %s.", pv.getName(), ModelHyperlinkNote.encodeTo(project), pDefDisplayName));
                                 ParameterValue convertedValue = ((SimpleParameterDefinition) pDef).createValue((String) pv.getValue());
                                 allParameters.put(pDef.getName(), convertedValue);
                                 description = Messages.BuildTriggerStepExecution_convertedParameterDescription(description, pDefDisplayName, invokingRun.toString());

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/TriggerBuildLinkAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/TriggerBuildLinkAction.java
@@ -1,0 +1,221 @@
+package org.jenkinsci.plugins.workflow.support.steps.build;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
+
+import hudson.AbortException;
+import hudson.model.Action;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Describable;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Queue;
+import hudson.model.Run;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.model.queue.ScheduleResult;
+import jenkins.model.Jenkins;
+import jenkins.model.ParameterizedJobMixIn;
+
+/**
+ * Action that shows an button on the build page that allows the user to start
+ * an downstream build whith predefined parameter values.
+ */
+public final class TriggerBuildLinkAction implements Action {
+
+    private static final Logger LOGGER = Logger.getLogger(BuildTriggerStepExecution.class.getName());
+    
+    private transient Run<?, ?> run;
+    private final String runId;
+    private transient FlowNode node;
+    private final String nodeId;
+    
+    private final String job;
+    private final String linkLabel;
+    private final String linkTooltip;
+    private final List<ParameterValue> parameters;
+
+
+    /**
+     * Creates an new BuildTriggerButtonBuildAction.
+     */
+    public TriggerBuildLinkAction(
+            Run<?, ?> run,
+            String job,
+            String linkLabel,
+            String linkTooltip,
+            List<ParameterValue> parameters,
+            FlowNode node) {
+        this.run = run;
+        this.runId = run.getExternalizableId();
+        this.node = node;
+        this.nodeId = node.getId();
+
+        this.job = job;
+        this.linkLabel = linkLabel;
+        this.linkTooltip = linkTooltip;
+        this.parameters = parameters;
+    }
+    
+    /**
+     * Called when user pushes button and starts the downstream build.
+     */
+    public HttpResponse doStartBuild() {
+        try {
+            Run<?, ?> invokingRun = getRun();
+            Item item = Jenkins.get().getItem(job, invokingRun.getParent(), Item.class);
+            if (item == null) {
+                throw new AbortException("No item named " + job + " found");
+            }
+            
+            final List<Action> actions = new ArrayList<>();
+            actions.add(
+                new CauseAction(
+                    new Cause.UpstreamCause(invokingRun), 
+                    new Cause.UserIdCause()
+                )
+            );
+            actions.add(new BuildUpstreamNodeAction(getNode(), invokingRun));
+    
+            if (item instanceof ParameterizedJobMixIn.ParameterizedJob) {
+                final ParameterizedJobMixIn.ParameterizedJob project = (ParameterizedJobMixIn.ParameterizedJob) item;
+    //            listener.getLogger().println("Scheduling project: " + ModelHyperlinkNote.encodeTo(project));
+    
+                getNode().addAction(new LabelAction(Messages.BuildTriggerStepExecution_building_(project.getFullDisplayName())));
+    
+                if (parameters != null) {
+                    actions.add(new ParametersAction(parameters));
+                }
+                
+                Queue.Item queueItem =
+                    ParameterizedJobMixIn.scheduleBuild2(
+                        (Job<?, ?>) project, -1, actions.toArray(new Action[actions.size()]));
+                if (queueItem == null || queueItem.getFuture() == null) {
+                    throw new AbortException("Failed to trigger build of " + project.getFullName());
+                }
+                
+            } else if (item instanceof Queue.Task){
+                if (parameters != null && !parameters.isEmpty()) {
+                    throw new AbortException("Item type does not support parameters");
+                }
+                
+                Queue.Task task = (Queue.Task) item;
+                getNode().addAction(new LabelAction(Messages.BuildTriggerStepExecution_building_(task.getFullDisplayName())));
+                
+                Integer quietPeriod = null;
+                try {
+                    Method getQuietPeriod = task.getClass().getMethod("getQuietPeriod");
+                    if (getQuietPeriod.getReturnType().equals(int.class)) {
+                        quietPeriod = (Integer) getQuietPeriod.invoke(task);
+                    }
+                } catch (NoSuchMethodException e) {
+                    // ignore, best effort only
+                } catch (IllegalAccessError | IllegalArgumentException | InvocationTargetException e) {
+                    LOGGER.log(Level.WARNING, "Could not determine quiet period of " + item.getFullName(), e);
+                }
+                if (quietPeriod == null) {
+                    quietPeriod = Jenkins.get().getQuietPeriod();
+                }
+                ScheduleResult scheduleResult = Jenkins.get().getQueue().schedule2(task, quietPeriod, actions);
+                if (scheduleResult.isRefused()) {
+                    throw new AbortException("Failed to trigger build of " + item.getFullName());
+                }
+            } else {
+                throw new AbortException("The item named " + item.getName() + " is a "
+                    + (item instanceof Describable
+                    ? ((Describable) item).getDescriptor().getDisplayName()
+                    : item.getClass().getName())
+                    + " which is not something that can be built");
+            }
+            return HttpResponses.forwardToPreviousPage();
+        } catch (IOException |IllegalAccessException  e) {
+            return HttpResponses.error(e);
+        }
+    }
+
+    /**
+     * Returns the {@link Run} which contains this action and is the upstream-build.
+     * Performs lazy loading, if run is not been loaded yet.
+     */
+    private Run<?, ?> getRun() {
+        if (run == null) {
+            run = Run.fromExternalizableId(runId);
+        }
+        return run;
+    }
+
+    /**
+     * Returns the {@link FlowNode} that has created the build link.
+     * Performs lazy loading, if node has not been loaded yet.
+     */
+    private FlowNode getNode() throws IOException {
+        if (node == null) {
+            Run<?, ?> run = getRun();
+            assert run instanceof WorkflowRun;
+            WorkflowRun workflow = (WorkflowRun) run;
+            FlowExecution execution = workflow.getExecution();
+            if (execution != null) {
+                node = execution.getNode(nodeId);
+            } else {
+                throw new IOException("Node could not be loaded: " + nodeId);
+            }
+        }
+        return node;
+    }
+
+    /**
+     * Return the label for the link.
+     */
+    public String getLinkLabel() {
+        return linkLabel;
+    }
+
+    /**
+     * Returns the tooltip for the link.
+     */
+    public String getLinkTooltip() {
+        return linkTooltip;
+    }
+
+    /**
+     * Should not appear in menu, so returns <code>null</code>.
+     */
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    /**
+     * Should not appear in menu, so returns <code>null</code>.
+     */
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+    
+    @Override
+    public String getUrlName() {
+        return "triggerDownstreamBuild";
+    }
+    
+    /**
+     * Returns the jenkins-relative URL for starting the downstream build.
+     */
+    public String getTriggerUrl() {
+        return getUrlName() + "/startBuild";
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep/DescriptorImpl/parameters.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep/DescriptorImpl/parameters.groovy
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStep;
+def st = namespace('jelly:stapler')
+def l = namespace('/lib/layout')
+l.ajax {
+    def jobName = request.getParameter('job')
+    if (jobName != null) {
+        // Cf. BuildTriggerStepExecution:
+        def contextName = request.getParameter('context')
+        def context = contextName != null ? app.getItemByFullName(contextName) : null
+        def job = app.getItem(jobName, (hudson.model.Item) context, hudson.model.Item)
+        if (job instanceof jenkins.model.ParameterizedJobMixIn.ParameterizedJob) {
+            def pdp = job.getProperty(hudson.model.ParametersDefinitionProperty)
+            if (pdp != null) {
+                // Cf. ParametersDefinitionProperty/index.jelly:
+                table(width: '100%', class: 'parameters') {
+                    for (parameterDefinition in pdp.parameterDefinitions) {
+                        tbody {
+                            // TODO JENKINS-26578 does not work for CredentialsParameterDefinition: pulldown is not populated because select.js is never loaded; <script> section in https://github.com/jenkinsci/credentials-plugin/commit/1045207207fb69d4dc1ede70d7ab743ad463708c not executed
+                            st.include(it: parameterDefinition, page: parameterDefinition.descriptor.valuePage)
+                        }
+                    }
+                }
+            } else {
+                text("${job.fullDisplayName} is not parameterized")
+            }
+        } else if (job instanceof hudson.model.Queue.Task) {
+            text("${job.fullDisplayName} is not parameterized")
+        } else if (job != null) {
+            text("${job.fullDisplayName} is not buildable")
+        } else {
+            text("no such job ${jobName}")
+        }
+    } else {
+        text('no job specified')
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep/config.jelly
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2014 Jesse Glick.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+    <j:set var="jobFieldId" value="${h.generateId()}"/>
+    <f:entry field="job" title="Project to Build">
+        <f:textbox onblur="loadParams()" id="${jobFieldId}"/>
+    </f:entry>
+    <f:entry field="linkLabel" title="Link label">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="linkTooltip" title="Link tooltip">
+        <f:textarea/>
+    </f:entry>
+    <f:entry title="Parameters">
+        <div id="params"/>
+        <script>
+            function loadParams() {
+                var div = $$('params');
+                new Ajax.Request('${descriptor.descriptorUrl}/parameters?job=' + encodeURIComponent($$('${jobFieldId}').value) + '&amp;context=' + encodeURIComponent('${descriptor.context}'), {
+                    method : 'get',
+                    onSuccess : function(x) {
+                        div.innerHTML = x.responseText;
+                        Behaviour.applySubtree(div);
+                    },
+                    onFailure : function(x) {
+                        div.innerHTML = "<b>ERROR</b>: Failed to load parameter definitions: " + x.statusText;
+                    }
+                });
+            }
+        </script>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep/help-job.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep/help-job.html
@@ -1,0 +1,7 @@
+<div>
+    Name of a downstream job to build when user clicks link on build page.
+    May be another Pipeline job, but more commonly a freestyle or other project.
+    Use a simple name if the job is in the same folder as this upstream Pipeline job;
+    otherwise can use relative paths like <code>../sister-folder/downstream</code>
+    or absolute paths like <code>/top-level-folder/nested-folder/downstream</code>.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep/help-linkLabel.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep/help-linkLabel.html
@@ -1,0 +1,3 @@
+<div>
+    Label for the link within the build page.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep/help-linkTooltip.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep/help-linkTooltip.html
@@ -1,0 +1,3 @@
+<div>
+    Tooltip for the link within the build page.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStep/help.html
@@ -1,0 +1,3 @@
+<div>
+    Adds a link to the build page, to allow the user to trigger an downstream build.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/TriggerBuildLinkAction/summary.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/TriggerBuildLinkAction/summary.jelly
@@ -1,0 +1,13 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <t:summary icon="orange_square.png">
+        <div title="${it.linkTooltip}"><a onclick="return triggerBuild(this)" href="${it.triggerUrl}">${it.linkLabel}</a></div>
+    </t:summary>
+    <script>
+    function triggerBuild(a) {
+        new Ajax.Request(a.href);
+        hoverNotification('Build gestartet', a.parentNode);
+        return false;
+    }
+    </script>
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStepRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStepRestartTest.java
@@ -1,0 +1,108 @@
+package org.jenkinsci.plugins.workflow.support.steps.build;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
+
+import hudson.model.BooleanParameterDefinition;
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
+import hudson.model.User;
+
+public class AddTriggerBuildLinkStepRestartTest {
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule
+    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    /**
+     * Tests starting the downstream job by user interaction after jenkins restart.
+     */
+    @Test
+    public void restartBetweenJobs() {
+
+        this.story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                final FreeStyleProject downstream = story.j.createFreeStyleProject("downstream");
+                downstream.addProperty(
+                    new ParametersDefinitionProperty(
+                        new StringParameterDefinition("branch", "master"),
+                        new BooleanParameterDefinition("extra", false, null))
+                );
+                final WorkflowJob upstream = story.j.jenkins.createProject(WorkflowJob.class, "upstream");
+                upstream.setDefinition(new CpsFlowDefinition(
+                    "addTriggerBuildLink job: 'downstream', linkLabel: 'Trigger delivery', linkTooltip: 'Delivers product to production.'", true));
+                AddTriggerBuildLinkStepRestartTest.this.story.j.assertBuildStatus(Result.SUCCESS, upstream.scheduleBuild2(0));
+
+                final FreeStyleBuild lastDownstreamRun = downstream.getLastBuild();
+                // Downstream build has not yet been started
+                assertThat(lastDownstreamRun, is(nullValue()));
+                final WorkflowRun lastUpstreamRun = upstream.getLastBuild();
+                final List<TriggerBuildLinkAction> triggerActions = lastUpstreamRun.getActions(TriggerBuildLinkAction.class);
+                assertThat(triggerActions, hasSize(1));
+            }
+        });
+
+        this.story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob upstream = story.j.jenkins.getItemByFullName("upstream", WorkflowJob.class);
+                FreeStyleProject downstream = story.j.jenkins.getItemByFullName("downstream", FreeStyleProject.class);
+                final WorkflowRun lastUpstreamRun = upstream.getLastBuild();
+                final List<TriggerBuildLinkAction> triggerActions = lastUpstreamRun.getActions(TriggerBuildLinkAction.class);
+                assertThat(triggerActions, hasSize(1));
+                TriggerBuildLinkAction triggerAction = triggerActions.get(0);
+                
+                // Start the downstream build
+                HttpResponse response = triggerAction.doStartBuild();
+                assertThat(response, is(HttpResponses.forwardToPreviousPage()));
+                
+                // now the downstream build has been started
+                FreeStyleBuild lastDownstreamRun = AddTriggerBuildLinkStepTest.getFirstBuild(downstream);
+                assertThat(lastDownstreamRun, is(not(nullValue())));
+                
+                final FlowExecution execution = lastUpstreamRun.getExecution();
+
+                List<BuildUpstreamNodeAction> actions = lastDownstreamRun.getActions(BuildUpstreamNodeAction.class);
+                assertEquals("action count", 1, actions.size());
+
+                BuildUpstreamNodeAction action = actions.get(0);
+                assertEquals("correct upstreamRunId", action.getUpstreamRunId(), lastUpstreamRun.getExternalizableId());
+                assertNotNull("valid upstreamNodeId", execution.getNode(action.getUpstreamNodeId()));
+                
+                // Check if the upstream cause and userid cause are present
+                Cause.UpstreamCause upstreamCause = lastDownstreamRun.getCause(Cause.UpstreamCause.class);
+                assertNotNull(upstreamCause);
+                assertEquals(lastUpstreamRun, upstreamCause.getUpstreamRun());
+                
+                Cause.UserIdCause userIdCause = lastDownstreamRun.getCause(Cause.UserIdCause.class);
+                assertNotNull(userIdCause);
+                assertThat(userIdCause.getUserId(), is(User.current().getId()));
+            }
+        });
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/AddTriggerBuildLinkStepTest.java
@@ -1,0 +1,114 @@
+package org.jenkinsci.plugins.workflow.support.steps.build;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
+
+import hudson.model.BooleanParameterDefinition;
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
+import hudson.model.User;
+
+@SuppressWarnings("nls")
+public final class AddTriggerBuildLinkStepTest {
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public LoggerRule logging = new LoggerRule();
+
+    @Before
+    public void runQuickly() throws IOException {
+        this.j.jenkins.setQuietPeriod(0);
+    }
+
+    @Test 
+    public void testAddBuildAction() throws Exception {
+        FreeStyleProject downstream = j.createFreeStyleProject("downstream");
+        downstream.addProperty(
+            new ParametersDefinitionProperty(
+                new StringParameterDefinition("branch", "master"), 
+                new BooleanParameterDefinition("extra", false, null))
+        );
+        WorkflowJob upstream = j.jenkins.createProject(WorkflowJob.class, "upstream");
+
+        upstream.setDefinition(new CpsFlowDefinition(
+            "addTriggerBuildLink job: 'downstream', linkLabel: 'Trigger delivery', linkTooltip: 'Delivers product to production.', parameters: [string(name: 'branch', value: 'feature/important')]", true));
+        j.assertBuildStatus(Result.SUCCESS, upstream.scheduleBuild2(0));
+
+        WorkflowRun lastUpstreamRun = upstream.getLastBuild();
+        FreeStyleBuild lastDownstreamRun = downstream.getLastBuild();
+        // Downstream build has not yet been started
+        assertThat(lastDownstreamRun, is(nullValue()));
+
+        List<TriggerBuildLinkAction> triggerActions = lastUpstreamRun.getActions(TriggerBuildLinkAction.class);
+        assertThat(triggerActions, hasSize(1));
+        TriggerBuildLinkAction triggerAction = triggerActions.get(0);
+        
+        // Start the downstream build
+        HttpResponse response = triggerAction.doStartBuild();
+        assertThat(response, is(HttpResponses.forwardToPreviousPage()));
+        
+        // now the downstream build has been started
+        lastDownstreamRun = getFirstBuild(downstream);
+        assertThat(lastDownstreamRun, is(not(nullValue())));
+        
+        final FlowExecution execution = lastUpstreamRun.getExecution();
+
+        List<BuildUpstreamNodeAction> actions = lastDownstreamRun.getActions(BuildUpstreamNodeAction.class);
+        assertEquals("action count", 1, actions.size());
+
+        BuildUpstreamNodeAction action = actions.get(0);
+        assertEquals("correct upstreamRunId", action.getUpstreamRunId(), lastUpstreamRun.getExternalizableId());
+        assertNotNull("valid upstreamNodeId", execution.getNode(action.getUpstreamNodeId()));
+        
+        // Check if the upstream cause and userid cause are present
+        Cause.UpstreamCause upstreamCause = lastDownstreamRun.getCause(Cause.UpstreamCause.class);
+        assertNotNull(upstreamCause);
+        assertEquals(lastUpstreamRun, upstreamCause.getUpstreamRun());
+        
+        Cause.UserIdCause userIdCause = lastDownstreamRun.getCause(Cause.UserIdCause.class);
+        assertNotNull(userIdCause);
+        assertThat(userIdCause.getUserId(), is(User.current().getId()));
+    }
+
+    static FreeStyleBuild getFirstBuild(FreeStyleProject downstream) throws InterruptedException {
+        for (int i = 0; i < 100; i++) {
+            FreeStyleBuild fb = downstream.getBuildByNumber(1);
+            if (fb != null) {
+                return fb;
+            }
+            Thread.sleep(100);
+        }
+        fail("Build not started");
+        return null;
+    }
+}


### PR DESCRIPTION
Added an new pipeline step that allows to add an customizable link on the build's page to start an downstream link after user interaction.