### PR TITLE
[JENKINS-60354] Mark that FlowInterruptedException is not used for actual interruption here

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,10 @@
     <properties>
         <revision>2.11</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.121.1</jenkins.version>
+        <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <scm-api.version>2.2.7</scm-api.version>
-        <workflow-step-api-plugin.version>2.18</workflow-step-api-plugin.version>
+        <workflow-step-api-plugin.version>2.22-20191211.162318-1</workflow-step-api-plugin.version> <!-- https://github.com/jenkinsci/workflow-step-api-plugin/pull/51 -->
         <workflow-support-plugin.version>3.1</workflow-support-plugin.version>
         <workflow-cps-plugin.version>2.62</workflow-cps-plugin.version>
     </properties>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.17</version>
+            <version>1.20</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <scm-api.version>2.2.7</scm-api.version>
-        <workflow-step-api-plugin.version>2.22-20191211.162318-1</workflow-step-api-plugin.version> <!-- https://github.com/jenkinsci/workflow-step-api-plugin/pull/51 -->
+        <workflow-step-api-plugin.version>2.22</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>3.1</workflow-support-plugin.version>
         <workflow-cps-plugin.version>2.62</workflow-cps-plugin.version>
     </properties>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
@@ -50,7 +50,7 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
                 }
             } else {
                 Result result = run.getResult();
-                trigger.context.onFailure(new FlowInterruptedException(result != null ? result : /* probably impossible */ Result.FAILURE, new DownstreamFailureCause(run)));
+                trigger.context.onFailure(new FlowInterruptedException(result != null ? result : /* probably impossible */ Result.FAILURE, false, new DownstreamFailureCause(run)));
             }
         }
         run.removeActions(BuildTriggerAction.class);


### PR DESCRIPTION
See [JENKINS-60354](https://issues.jenkins-ci.org/browse/JENKINS-60354) and https://github.com/jenkinsci/workflow-step-api-plugin/pull/51.