### PR TITLE
 Bump plugin parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.43</version>
+        <version>3.54</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Bumps the [plugin parent POM](https://github.com/jenkinsci/plugin-pom) from 3.43 to 3.54.

See [the changelog](https://github.com/jenkinsci/plugin-pom/releases) and the full diff in [the compare view](https://github.com/jenkinsci/plugin-pom/compare/plugin-3.43...plugin-3.54).