### PR TITLE
[JENKINS-60779] Do not log conversion warnings for choice-like parameter definitions

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -175,10 +175,14 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
                             ParameterValue pv = allParameters.get(pDef.getName());
                             if (pv instanceof StringParameterValue) {
                                 String pDefDisplayName = pDef.getDescriptor().getDisplayName();
-                                listener.getLogger().println(String.format("The parameter '%s' did not have the type expected by %s. Converting to %s.", pv.getName(), ModelHyperlinkNote.encodeTo(project), pDefDisplayName));
+                                // ExtensibleChoiceParameterDefinition is similar to ChoiceParameterDefinition, and a type
+                                // mismatch is expected, so we want to do the conversion, but not log a warning.
+                                if (!pDef.getClass().getName().equals("jp.ikedam.jenkins.plugins.extensible_choice_parameter.ExtensibleChoiceParameterDefinition")) {
+                                    listener.getLogger().println(String.format("The parameter '%s' did not have the type expected by %s. Converting to %s.", pv.getName(), ModelHyperlinkNote.encodeTo(project), pDefDisplayName));
+                                    description = Messages.BuildTriggerStepExecution_convertedParameterDescription(description, pDefDisplayName, invokingRun.toString());
+                                }
                                 ParameterValue convertedValue = ((SimpleParameterDefinition) pDef).createValue((String) pv.getValue());
                                 allParameters.put(pDef.getName(), convertedValue);
-                                description = Messages.BuildTriggerStepExecution_convertedParameterDescription(description, pDefDisplayName, invokingRun.toString());
                             }
                         }
                         // TODO: Should we try to detect some unconvertible cases and fail here instead of allowing it?

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -54,8 +54,10 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
     private static final Logger LOGGER = Logger.getLogger(BuildTriggerStepExecution.class.getName());
     private static final Set<String> CHOICE_PARAMETER_DEFINITION_LIKE_CLASSES = ImmutableSet.of(
             "jp.ikedam.jenkins.plugins.extensible_choice_parameter.ExtensibleChoiceParameterDefinition",
+            // The names are misleading, but these classes are all parameter definitions, not parameters.
             "org.biouno.unochoice.CascadeChoiceParameter",
-            "org.biouno.unochoice.ChoiceParameter");
+            "org.biouno.unochoice.ChoiceParameter",
+            "org.biouno.unochoice.DynamicReferenceParameter");
 
     @StepContextParameter
     private transient TaskListener listener;


### PR DESCRIPTION
See [JENKINS-60779](https://issues.jenkins-ci.org/browse/JENKINS-60779).

Not sure about adding tests for this, I'd really prefer not to have a dependency on either of the relevant plugins, even in test scope.