### PR TITLE
JENKINS-62483: Maintain parameter list order

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -42,7 +42,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -157,7 +157,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
     }
 
     private List<ParameterValue> completeDefaultParameters(List<ParameterValue> parameters, Job<?,?> project) throws AbortException {
-        Map<String,ParameterValue> allParameters = new HashMap<>();
+        Map<String,ParameterValue> allParameters = new LinkedHashMap<>();
         for (ParameterValue pv : parameters) {
             allParameters.put(pv.getName(), pv);
         }


### PR DESCRIPTION
See [JENKINS-62483](https://issues.jenkins-ci.org/browse/JENKINS-62483).

When the plugin processes the list of job parameters, it stores them in a randomly ordered map and passes on this map to the job being triggered. If a job has a large amount of parameters, this makes it more difficult for a user to look up a build's parameters. This PR ensures that parameters are always passed on in the order that the job defines.