### PR TITLE
[JENKINS-62305] Make password parameters work with the build step in Jenkins 2.236+

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin()
+buildPlugin(useAci: true, configurations: [
+  [ platform: 'linux', jdk: '8' ],
+  [ platform: 'windows', jdk: '8' ],
+  [ platform: 'linux', jdk: '11', jenkins: '2.236' ]
+])

--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@
 
 Adds the Pipeline `build` step, which triggers builds of other jobs.
 
+### Passing secret values to other jobs
+
+The recommended approach to pass secret values using the `build` step is to use credentials parameters:
+
+```
+build(job: 'foo', parameters: [credentials('parameter-name', 'credentials-id')])
+```
+
+See [the user guide for the Credentials Plugin](https://plugins.jenkins.io/credentials/) for a general overview of how credentials work in Jenkins and how they can be configured, and [the documentation for the Credentials Binding Plugin](https://plugins.jenkins.io/credentials-binding/) for an overview of how to access and use credentials from a Pipeline.
+
+The `build` step also supports passing password parameters, but this is not recommended.
+The plaintext secret may be persisted as part of the Pipeline's internal state, and it will not be automatically masked if it appears in the build log.
+Here is an example for reference:
+
+```
+build(job: 'foo', parameters: [password('parameter-name', 'secret-value')])
+```
+
 ## Version History
 
 See [the changelog](CHANGELOG.md).

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.54</version>
+        <version>4.4</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -40,108 +40,99 @@
     <properties>
         <revision>2.13</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.176.4</jenkins.version>
         <java.level>8</java.level>
-        <scm-api.version>2.2.7</scm-api.version>
-        <workflow-step-api-plugin.version>2.22</workflow-step-api-plugin.version>
-        <workflow-support-plugin.version>3.1</workflow-support-plugin.version>
-        <workflow-cps-plugin.version>2.62</workflow-cps-plugin.version>
+        <useBeta>true</useBeta>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.176.x</artifactId>
+                <version>11</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow-step-api-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.33</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>${workflow-support-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.50</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.20</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow-step-api-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>${workflow-support-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow-cps-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow-cps-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.31</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
-            <version>2.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.18</version>
+             <scope>test</scope>
+         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>${scm-api.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-            <version>${scm-api.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -153,7 +144,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>6.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
@@ -157,6 +157,24 @@ public class BuildTriggerStep extends AbstractStepImpl {
             );
         }
 
+        @Override
+        public UninstantiatedDescribable customUninstantiate(UninstantiatedDescribable step) {
+            Map<String, Object> newStepArgs = copyMapReplacingEntry(step.getArguments(), "parameters", List.class, parameters -> parameters.stream()
+                    .map(parameter -> {
+                        if (parameter instanceof UninstantiatedDescribable) {
+                            UninstantiatedDescribable ud = (UninstantiatedDescribable) parameter;
+                            if (ud.getSymbol().equals("password")) {
+                                Map<String, Object> newParamArgs = copyMapReplacingEntry(ud.getArguments(), "value", Secret.class, Secret::getPlainText);
+                                return ud.withArguments(newParamArgs);
+                            }
+                        }
+                        return parameter;
+                    })
+                    .collect(Collectors.toList())
+            );
+            return step.withArguments(newStepArgs);
+        }
+
         /**
          * Copy a map, replacing the entry with the specified key if it matches the specified type.
          */

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
@@ -141,19 +141,18 @@ public class BuildTriggerStep extends AbstractStepImpl {
             if (DescribableModel.of(PasswordParameterValue.class).getParameter("value").getErasedType() != Secret.class) {
                 return map;
             }
-            return copyMapReplacingEntry(map, "parameters", List.class, parameters ->
-                parameters.stream()
-                        .map(parameter -> {
-                            if (parameter instanceof UninstantiatedDescribable) {
-                                UninstantiatedDescribable ud = (UninstantiatedDescribable) parameter;
-                                if (ud.getSymbol().equals("password")) {
-                                    Map<String, Object> newArguments = copyMapReplacingEntry(ud.getArguments(), "value", String.class, Secret::fromString);
-                                    return ud.withArguments(newArguments);
-                                }
+            return copyMapReplacingEntry(map, "parameters", List.class, parameters -> parameters.stream()
+                    .map(parameter -> {
+                        if (parameter instanceof UninstantiatedDescribable) {
+                            UninstantiatedDescribable ud = (UninstantiatedDescribable) parameter;
+                            if (ud.getSymbol().equals("password")) {
+                                Map<String, Object> newArguments = copyMapReplacingEntry(ud.getArguments(), "value", String.class, Secret::fromString);
+                                return ud.withArguments(newArguments);
                             }
-                            return parameter;
-                        })
-                        .collect(Collectors.toList())
+                        }
+                        return parameter;
+                    })
+                    .collect(Collectors.toList())
             );
         }
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/config.jelly
@@ -38,7 +38,7 @@ THE SOFTWARE.
     <f:entry field="quietPeriod" title="Quiet period">
         <f:number clazz="number"/>
     </f:entry>
-    <f:entry title="Parameters">
+    <f:entry title="Parameters" help="${descriptor.getHelpFile('parameters')}">
         <div id="params"/>
         <script>
             function loadParams() {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/config.jelly
@@ -38,7 +38,7 @@ THE SOFTWARE.
     <f:entry field="quietPeriod" title="Quiet period">
         <f:number clazz="number"/>
     </f:entry>
-    <f:entry title="Parameters" help="${descriptor.getHelpFile('parameters')}">
+    <f:entry field="parameters" title="Parameters">
         <div id="params"/>
         <script>
             function loadParams() {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help-parameters.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help-parameters.html
@@ -1,0 +1,6 @@
+<div>
+    A list of parameters to pass to the downstream job.
+
+    When passing secrets to downstream jobs, prefer credentials parameters over password parameters.
+    See <a href="https://plugins.jenkins.io/pipeline-build-step/">the documentation</a> for details.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help-parameters.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help-parameters.html
@@ -1,6 +1,5 @@
 <div>
     A list of parameters to pass to the downstream job.
-
     When passing secrets to downstream jobs, prefer credentials parameters over password parameters.
     See <a href="https://plugins.jenkins.io/pipeline-build-step/">the documentation</a> for details.
 </div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -22,6 +22,7 @@ import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.PasswordParameterDefinition;
+import hudson.model.PasswordParameterValue;
 import hudson.model.Queue;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -577,6 +578,9 @@ public class BuildTriggerStepTest {
         step.setParameters(Arrays.asList(new StringParameterValue("branch", "default"), new BooleanParameterValue("correct", true)));
         // Note: This does not actually test the format of the JSON produced by the snippet generator for parameters, see generateSnippet* for tests of that behavior.
         st.assertRoundTrip(step, "build job: 'downstream', parameters: [string(name: 'branch', value: 'default'), booleanParam(name: 'correct', value: true)]");
+        // Passwords parameters are handled specially via CustomDescribableModel
+        step.setParameters(Arrays.asList(new PasswordParameterValue("param-name", "secret")));
+        st.assertRoundTrip(step, "build job: 'downstream', parameters: [password(name: 'param-name', value: 'secret')]");
     }
 
     @Issue("JENKINS-26093")

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -615,6 +615,7 @@ public class BuildTriggerStepTest {
         } catch (Exception e) {
             // TODO: Jenkins 2.236+ broke structs-based databinding and introspection of PasswordParameterValue, JENKINS-62305.
             assumeThat(e.getMessage(), not(containsString("There's no @DataBoundConstructor on any constructor of class hudson.util.Secret")));
+            throw e;
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -74,7 +74,10 @@ import org.jvnet.hudson.test.SleepBuilder;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.recipes.LocalData;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeThat;
 
 public class BuildTriggerStepTest {
 
@@ -605,7 +608,12 @@ public class BuildTriggerStepTest {
 
     @Test
     public void buildStepDocs() throws Exception {
-        SnippetizerTester.assertDocGeneration(BuildTriggerStep.class);
+        try {
+            SnippetizerTester.assertDocGeneration(BuildTriggerStep.class);
+        } catch (Exception e) {
+            // TODO: Jenkins 2.236+ broke structs-based databinding and introspection of PasswordParameterValue, JENKINS-62305.
+            assumeThat(e.getMessage(), not(containsString("There's no @DataBoundConstructor on any constructor of class hudson.util.Secret")));
+        }
     }
 
     @Test public void automaticParameterConversion() throws Exception {


### PR DESCRIPTION
See [JENKINS-62305](https://issues.jenkins-ci.org/browse/JENKINS-62305).

https://github.com/jenkinsci/jenkins/pull/4630 changed the `@DataBoundConstructor` for `PasswordParameterValue` so that one of its parameters is a `Secret`, but `Secret` is not supported by data binding via `DescribableModel` in `structs`. 

This PR uses `CustomDescribableModel` to maintain compatibility with existing uses of the `build` step with password parameters, and adds documentation explaining that credentials should be preferred over password parameters going forward.

TODO: Do we want to add a runtime warning (e.g. message in the build log) any time a password parameter is used with the `build` step? My understanding is that while password parameters are not ideal, they are not completely broken, so I am a little hesitant to add a warning if the issues are relatively minor.

Other things that are broken and that this PR does not attempt to fix:
* Snippet generation for password parameters. I am not sure exactly what is wrong, but the new UI control for passwords from https://github.com/jenkinsci/jenkins/pull/3991 seems to be non-interactive in the snippet generator. Additionally, the generated Groovy snippet shows `<object of type hudson.util.Secret>`, so we'd need to implement `customUninstantiate` to fix that.
* Doc generation for the `build` step (https://www.jenkins.io/doc/pipeline/steps/pipeline-build-step/). Once the job that creates those docs is updated to run against Jenkins 2.236 or higher, it will fail. A special case will need to be added to https://github.com/jenkins-infra/pipeline-steps-doc-generator to handle `PasswordParameterValue`.