### PR TITLE
Recommend the Pipeline Snippet Generator in help

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help.html
@@ -1,3 +1,10 @@
 <div>
+    <p>
     Triggers a new build for a given job.
+    </p>
+    <p>
+    Use the <a href="https://jenkins.io/redirect/pipeline-snippet-generator"><strong>Pipeline Snippet Generator</strong></a> to generate a sample pipeline script for the <code>build</code> step.
+    The snippet generator provides additional help for the <code>build</code> step through the help icons on the right side of the build step definition page.
+    The additional help includes a detailed description of the <code>wait</code> argument and the options available with the <code>wait</code> argument in your Jenkins installation.
+    </p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help.html
@@ -5,6 +5,9 @@
     <p>
     Use the <a href="https://jenkins.io/redirect/pipeline-snippet-generator"><strong>Pipeline Snippet Generator</strong></a> to generate a sample pipeline script for the <code>build</code> step.
     The snippet generator provides additional help for the <code>build</code> step through the help icons on the right side of the build step definition page.
-    The additional help includes a detailed description of the <code>wait</code> argument and the options available with the <code>wait</code> argument in your Jenkins installation.
+    The additional help includes a detailed description of the <code>wait</code> argument and the return values available from the <code>build</code> step when <code>wait</code> is enabled.
+    </p>
+    <p>
+    If the <code>wait</code> argument is <code>true</code>, the return value of the <code>build</code> step is an object containing read-only properties related to the completed build.
     </p>
 </div>


### PR DESCRIPTION
## Recommend the pipeline editor in build step help

A frequent complaint in the Pipeline Steps reference [doc comments](https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709) is that the `wait` argument is not documented on https://www.jenkins.io/doc/pipeline/steps/pipeline-build-step/ .  The `wait` argument can't be documented on that static page because the arguments that it accepts are dynamically determined based on the installed plugins.

Suggest that the user read the online help so that they can see the best description of the values of `wait` on their Jenkins installation.
