### PR TITLE
Migrate from `RestartableJenkinsRule` to `JenkinsSessionRule`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepRestartTest.java
@@ -5,7 +5,6 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import hudson.model.Result;
 import hudson.model.queue.QueueTaskFuture;
-import java.io.IOException;
 import java.util.Arrays;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
@@ -17,7 +16,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 /**
  * @author Vivek Pandey
@@ -25,63 +25,51 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
 public class BuildTriggerStepRestartTest extends Assert {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
-    @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    @Rule public JenkinsSessionRule sessions = new JenkinsSessionRule();
 
     @Test
-    public void restartBetweenJobs() throws IOException {
+    public void restartBetweenJobs() throws Throwable {
 
-        story.addStep(new Statement() {
-                          @Override
-                          public void evaluate() throws Throwable {
-                              story.j.jenkins.setNumExecutors(0);
-                              FreeStyleProject p1 = story.j.createFreeStyleProject("test1");
-                              WorkflowJob foo = story.j.jenkins.createProject(WorkflowJob.class, "foo");
+        sessions.then(j -> {
+                              j.jenkins.setNumExecutors(0);
+                              FreeStyleProject p1 = j.createFreeStyleProject("test1");
+                              WorkflowJob foo = j.createProject(WorkflowJob.class, "foo");
                               foo.setDefinition(new CpsFlowDefinition("build 'test1'", true));
                               WorkflowRun b = foo.scheduleBuild2(0).waitForStart();
-                              story.j.waitForMessage("Scheduling project", b);
+                              j.waitForMessage("Scheduling project", b);
                               CpsFlowExecution e = (CpsFlowExecution) b.getExecutionPromise().get();
                               e.waitForSuspension();
-                              assertFreeStyleProjectsInQueue(1);
+                              assertFreeStyleProjectsInQueue(1, j);
                           }
-                      }
         );
 
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                assertFreeStyleProjectsInQueue(1);
-                story.j.jenkins.setNumExecutors(2);
-            }
+        sessions.then(j -> {
+                assertFreeStyleProjectsInQueue(1, j);
+                j.jenkins.setNumExecutors(2);
         });
 
-        story.addStep(new Statement() {
-                          @Override
-                          public void evaluate() throws Throwable {
-                              story.j.waitUntilNoActivity();
-                              FreeStyleProject p1 = story.j.jenkins.getItemByFullName("test1", FreeStyleProject.class);
+        sessions.then(j -> {
+                              j.waitUntilNoActivity();
+                              FreeStyleProject p1 = j.jenkins.getItemByFullName("test1", FreeStyleProject.class);
                               FreeStyleBuild r = p1.getLastBuild();
                               assertNotNull(r);
                               assertEquals(1, r.number);
                               assertEquals(Result.SUCCESS, r.getResult());
-                              assertFreeStyleProjectsInQueue(0);
-                              WorkflowJob foo = story.j.jenkins.getItemByFullName("foo", WorkflowJob.class);
+                              assertFreeStyleProjectsInQueue(0, j);
+                              WorkflowJob foo = j.jenkins.getItemByFullName("foo", WorkflowJob.class);
                               assertNotNull(foo);
                               WorkflowRun r2 = foo.getLastBuild();
                               assertNotNull(r2);
-                              story.j.assertBuildStatusSuccess(r2);
-            }
+                              j.assertBuildStatusSuccess(r2);
         });
 
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                story.j.jenkins.getItemByFullName("test1", FreeStyleProject.class).getBuildByNumber(1).delete();
-            }
+        sessions.then(j -> {
+                j.jenkins.getItemByFullName("test1", FreeStyleProject.class).getBuildByNumber(1).delete();
         });
     }
 
-    private void assertFreeStyleProjectsInQueue(int count) {
-        Queue.Item[] items = story.j.jenkins.getQueue().getItems();
+    private static void assertFreeStyleProjectsInQueue(int count, JenkinsRule j) {
+        Queue.Item[] items = j.jenkins.getQueue().getItems();
         int actual = 0;
         for (Queue.Item item : items) {
             if (item.task instanceof FreeStyleProject) {


### PR DESCRIPTION
We seem to be generally preferring `JenkinsSessionRule` to `RestartableJenkinsRule`. The main benefit to `JenkinsSessionRule` is that `#then` runs immediately, so it plays nicely with things like `@After.`