### PR TITLE
[JENKINS-60995] Implement a specific UpstreamCause class containing the nodeId that triggered the build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -81,7 +81,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
         }
 
         List<Action> actions = new ArrayList<>();
-        actions.add(new CauseAction(new Cause.UpstreamCause(invokingRun)));
+        actions.add(new CauseAction(new BuildUpstreamCause(node, invokingRun)));
         actions.add(new BuildUpstreamNodeAction(node, invokingRun));
 
         if (item instanceof ParameterizedJobMixIn.ParameterizedJob) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildUpstreamCause.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildUpstreamCause.java
@@ -1,0 +1,33 @@
+package org.jenkinsci.plugins.workflow.support.steps.build;
+
+import hudson.model.Cause;
+import hudson.model.Run;
+import java.util.Objects;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+
+public class BuildUpstreamCause extends Cause.UpstreamCause {
+    private final String nodeId;
+
+    public BuildUpstreamCause(FlowNode node, Run<?, ?> invokingRun) {
+        super(invokingRun);
+        this.nodeId = node.getId();
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        BuildUpstreamCause that = (BuildUpstreamCause) o;
+        return Objects.equals(nodeId, that.nodeId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), nodeId);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -145,7 +145,10 @@ public class BuildTriggerStepTest {
 
         List<BuildUpstreamCause> upstreamCauses = new ArrayList<>();
         for (Run<FreeStyleProject, FreeStyleBuild> downstreamRun : downstream.getBuilds()) {
-            upstreamCauses.addAll(downstreamRun.getCauses().stream().filter(BuildUpstreamCause.class::isInstance).map(BuildUpstreamCause.class::cast).collect(Collectors.toList()));
+            upstreamCauses.addAll(downstreamRun.getCauses().stream()
+                .filter(BuildUpstreamCause.class::isInstance)
+                .map(BuildUpstreamCause.class::cast)
+                .collect(Collectors.toList()));
         }
         assertThat("There should be as many upstream causes as upstream builds", upstreamCauses, hasSize(numberOfUpstreamBuilds));
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -35,8 +35,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import jenkins.branch.MultiBranchProjectFactory;
@@ -50,6 +52,9 @@ import jenkins.scm.impl.mock.MockSCMDiscoverBranches;
 import jenkins.scm.impl.mock.MockSCMNavigator;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
 import org.apache.commons.lang.StringUtils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -62,7 +67,6 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -83,6 +87,8 @@ import org.jvnet.hudson.test.recipes.LocalData;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeThat;
 
 public class BuildTriggerStepTest {
@@ -124,25 +130,37 @@ public class BuildTriggerStepTest {
         WorkflowJob upstream = j.jenkins.createProject(WorkflowJob.class, "upstream");
 
         upstream.setDefinition(new CpsFlowDefinition("build 'downstream'", true));
-        j.assertBuildStatus(Result.SUCCESS, upstream.scheduleBuild2(0));
+        int numberOfUpstreamBuilds = 3;
+        for (int i = 0; i < numberOfUpstreamBuilds; i++) {
+            upstream.scheduleBuild2(0);
+            // Wait a bit before scheduling next one
+            Thread.sleep(100);
+        }
+        for (WorkflowRun upstreamRun : upstream.getBuilds()) {
+            j.waitForCompletion(upstreamRun);
+            j.assertBuildStatus(Result.SUCCESS, upstreamRun);
+        }
+        // Wait for all downstream builds to complete
+        j.waitUntilNoActivity();
 
-        WorkflowRun lastUpstreamRun = upstream.getLastBuild();
-        FreeStyleBuild lastDownstreamRun = downstream.getLastBuild();
+        List<BuildUpstreamCause> upstreamCauses = new ArrayList<>();
+        for (Run<FreeStyleProject, FreeStyleBuild> downstreamRun : downstream.getBuilds()) {
+            upstreamCauses.addAll(downstreamRun.getCauses().stream().filter(BuildUpstreamCause.class::isInstance).map(BuildUpstreamCause.class::cast).collect(Collectors.toList()));
+        }
+        assertThat("There should be as many upstream causes as upstream builds", upstreamCauses, hasSize(numberOfUpstreamBuilds));
 
-        final FlowExecution execution = lastUpstreamRun.getExecution();
-
-        FlowNode buildTriggerNode = findFirstNodeWithDescriptor(execution, BuildTriggerStep.DescriptorImpl.class);
-        assertNotNull(buildTriggerNode);
-
-        List<BuildUpstreamCause> causes = lastDownstreamRun.getCauses().stream().filter(BuildUpstreamCause.class::isInstance).map(BuildUpstreamCause.class::cast).collect(Collectors.toList());
-        assertEquals("action count", 1, causes.size());
-
-        BuildUpstreamCause action = causes.get(0);
-        assertEquals("correct upstreamRun", action.getUpstreamRun(), lastUpstreamRun);
-        assertEquals("valid upstreamNodeId", buildTriggerNode, execution.getNode(action.getNodeId()));
+        Set<WorkflowRun> ups = new HashSet<>();
+        for (BuildUpstreamCause up : upstreamCauses) {
+            WorkflowRun upstreamRun = (WorkflowRun) up.getUpstreamRun();
+            ups.add(upstreamRun);
+            FlowExecution execution = upstreamRun.getExecution();
+            FlowNode buildTriggerNode = findFirstNodeWithDescriptor(execution, BuildTriggerStep.DescriptorImpl.class);
+            assertEquals("node id should be build trigger node", buildTriggerNode, execution.getNode(up.getNodeId()));
+        }
+        assertEquals("There should be as many upstream causes as referenced upstream builds", numberOfUpstreamBuilds, ups.size());
     }
 
-    private static FlowNode findFirstNodeWithDescriptor(FlowExecution execution, Class cls) {
+    private static FlowNode findFirstNodeWithDescriptor(FlowExecution execution, Class<BuildTriggerStep.DescriptorImpl> cls) {
         for (FlowNode node : new FlowGraphWalker(execution)) {
             if (node instanceof StepAtomNode) {
                 StepAtomNode stepAtomNode = (StepAtomNode) node;


### PR DESCRIPTION
This is part of a bigger change for blueocean in order to fix downstream links.
* (master) https://github.com/jenkinsci/blueocean-plugin/pull/2187
* (backport on 1.24.x) https://github.com/jenkinsci/blueocean-plugin/pull/2188

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
