### PR TITLE
Remove usages of Guice

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
@@ -12,12 +12,17 @@ import hudson.model.ParameterValue;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.PasswordParameterValue;
 import hudson.model.Queue;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
@@ -27,9 +32,11 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.structs.describable.CustomDescribableModel;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.util.StaplerReferer;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -39,7 +46,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-public class BuildTriggerStep extends AbstractStepImpl {
+public class BuildTriggerStep extends Step {
 
     private final String job;
     private List<ParameterValue> parameters;
@@ -88,12 +95,13 @@ public class BuildTriggerStep extends AbstractStepImpl {
         this.propagate = propagate;
     }
 
-    @Extension
-    public static class DescriptorImpl extends AbstractStepDescriptorImpl implements CustomDescribableModel {
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new BuildTriggerStepExecution(this, context);
+    }
 
-        public DescriptorImpl() {
-            super(BuildTriggerStepExecution.class);
-        }
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor implements CustomDescribableModel {
 
         // Note: This is necessary because the JSON format of the parameters produced by config.jelly when
         // using the snippet generator does not match what would be neccessary for databinding to work automatically.
@@ -187,6 +195,13 @@ public class BuildTriggerStep extends AbstractStepImpl {
                 }
             }
             return newMap;
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            Set<Class<?>> context = new HashSet<>();
+            Collections.addAll(context, FlowNode.class, Run.class, TaskListener.class);
+            return Collections.unmodifiableSet(context);
         }
 
         @Override


### PR DESCRIPTION
Experimenting with removing deprecated usages of Guice. In its current form, `BuildTriggerStepTest#storedForm` fails, so this PR is not ready for merge. The error is:

<details>
<summary>Stack trace</summary>
<br>
<pre>
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 5.58 s <<< FAILURE! - in org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStepTest
[ERROR] org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStepTest.storedForm  Time elapsed: 5.525 s  <<< FAILURE!
java.lang.AssertionError: 
unexpected build status; build log was:
------
Started by user unknown or anonymous
Running in Durability level: MAX_SURVIVABILITY
[Pipeline] build
Scheduling project: ds
Starting building: ds #1
Resuming build at Mon Jan 03 16:36:18 PST 2022 after Jenkins restart
[Pipeline] End of Pipeline
an exception which occurred:
        in field org.jenkinsci.plugins.workflow.cps.CpsThread.step
        in object org.jenkinsci.plugins.workflow.cps.CpsThread@6f8622c1
        in object of type org.jenkinsci.plugins.workflow.cps.CpsThread
        in object of type java.util.TreeMap
        in field org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.threads
        in object org.jenkinsci.plugins.workflow.cps.CpsThreadGroup@74c3e926
        in object of type org.jenkinsci.plugins.workflow.cps.CpsThreadGroup
Caused: java.io.InvalidClassException: org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStepExecution; Class does not extend stream superclass
        at org.jboss.marshalling.river.RiverUnmarshaller.doReadClassDescriptor(RiverUnmarshaller.java:1046)
        at org.jboss.marshalling.river.RiverUnmarshaller.doReadNewObject(RiverUnmarshaller.java:1355)
        at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:272)
        at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:220)
        at org.jboss.marshalling.river.RiverUnmarshaller.readFields(RiverUnmarshaller.java:1853)
        at org.jboss.marshalling.river.RiverUnmarshaller.doInitSerializable(RiverUnmarshaller.java:1767)
        at org.jboss.marshalling.river.RiverUnmarshaller.doReadNewObject(RiverUnmarshaller.java:1395)
        at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:272)
        at org.jboss.marshalling.river.BlockUnmarshaller.readObject(BlockUnmarshaller.java:149)
        at org.jboss.marshalling.river.BlockUnmarshaller.readObject(BlockUnmarshaller.java:135)
        at org.jboss.marshalling.MarshallerObjectInputStream.readObjectOverride(MarshallerObjectInputStream.java:53)
        at org.jboss.marshalling.river.RiverObjectInputStream.readObjectOverride(RiverObjectInputStream.java:307)
        at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:484)
        at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:451)
        at java.base/java.util.TreeMap.buildFromSorted(TreeMap.java:2563)
        at java.base/java.util.TreeMap.buildFromSorted(TreeMap.java:2503)
        at java.base/java.util.TreeMap.readObject(TreeMap.java:2450)
        at org.jboss.marshalling.reflect.JDKSpecific$SerMethods.callReadObject(JDKSpecific.java:100)
        at org.jboss.marshalling.reflect.SerializableClass.callReadObject(SerializableClass.java:212)
        at org.jboss.marshalling.river.RiverUnmarshaller.doInitSerializable(RiverUnmarshaller.java:1746)
        at org.jboss.marshalling.river.RiverUnmarshaller.doReadNewObject(RiverUnmarshaller.java:1395)
        at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:272)
        at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:220)
        at org.jboss.marshalling.river.RiverUnmarshaller.readFields(RiverUnmarshaller.java:1853)
        at org.jboss.marshalling.river.RiverUnmarshaller.doInitSerializable(RiverUnmarshaller.java:1767)
        at org.jboss.marshalling.river.RiverUnmarshaller.doReadNewObject(RiverUnmarshaller.java:1395)
        at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:272)
        at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:205)
        at org.jboss.marshalling.AbstractObjectInput.readObject(AbstractObjectInput.java:41)
        at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverReader$SandboxedUnmarshaller.lambda$readObject$0(RiverReader.java:250)
        at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox.runInSandbox(GroovySandbox.java:237)
        at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverReader$SandboxedUnmarshaller.sandbox(RiverReader.java:237)
        at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverReader$SandboxedUnmarshaller.readObject(RiverReader.java:250)
        at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$2.onSuccess(CpsFlowExecution.java:793)
        at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$2.onSuccess(CpsFlowExecution.java:786)
        at org.jenkinsci.plugins.workflow.support.concurrent.Futures$1.run(Futures.java:153)
        at com.google.common.util.concurrent.MoreExecutors$SameThreadExecutorService.execute(MoreExecutors.java:253)
        at com.google.common.util.concurrent.ExecutionList$RunnableExecutorPair.execute(ExecutionList.java:149)
        at com.google.common.util.concurrent.ExecutionList.add(ExecutionList.java:105)
        at com.google.common.util.concurrent.AbstractFuture.addListener(AbstractFuture.java:155)
        at org.jenkinsci.plugins.workflow.support.concurrent.Futures.addCallback(Futures.java:163)
        at org.jenkinsci.plugins.workflow.support.concurrent.Futures.addCallback(Futures.java:93)
        at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.loadProgramAsync(CpsFlowExecution.java:783)
        at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:750)
        at org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:691)
        at org.jenkinsci.plugins.workflow.job.WorkflowRun.onLoad(WorkflowRun.java:550)
        at hudson.model.RunMap.retrieve(RunMap.java:225)
        at hudson.model.RunMap.retrieve(RunMap.java:57)
        at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:501)
        at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:483)
        at jenkins.model.lazy.AbstractLazyLoadRunMap.getByNumber(AbstractLazyLoadRunMap.java:381)
        at hudson.model.RunMap.getById(RunMap.java:205)
        at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.run(WorkflowRun.java:940)
        at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.get(WorkflowRun.java:951)
        at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$1.computeNext(FlowExecutionList.java:65)
        at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$1.computeNext(FlowExecutionList.java:57)
        at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:143)
        at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:138)
        at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$ItemListenerImpl.onLoaded(FlowExecutionList.java:178)
        at jenkins.model.Jenkins.<init>(Jenkins.java:1019)
        at hudson.model.Hudson.<init>(Hudson.java:85)
        at org.jvnet.hudson.test.JenkinsRule.newHudson(JenkinsRule.java:688)
        at org.jvnet.hudson.test.JenkinsRule.before(JenkinsRule.java:404)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:595)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
Caused: java.io.IOException: Failed to load build state
        at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$3.onSuccess(CpsFlowExecution.java:865)
        at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$3.onSuccess(CpsFlowExecution.java:863)
        at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$4$1.run(CpsFlowExecution.java:917)
        at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.run(CpsVmExecutorService.java:38)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:131)
        at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:59)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Finished: FAILURE

------

Expected: is <SUCCESS>
     but: was <FAILURE>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.junit.Assert.assertThat(Assert.java:964)
        at org.jvnet.hudson.test.JenkinsRule.assertBuildStatus(JenkinsRule.java:1439)
        at org.jvnet.hudson.test.JenkinsRule.assertBuildStatusSuccess(JenkinsRule.java:1468)
        at org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStepTest.storedForm(BuildTriggerStepTest.java:518)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:601)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.lang.Thread.run(Thread.java:829)
</pre>
</details>

Retaining `AbstractStepImpl` as in jenkinsci/workflow-step-api-plugin#81 does not chase the problem away (not that I expected it to, as in this case the `AbstractStepExecutionImpl` keeps a `transient` reference to its `AbstractStepImpl`). The stack trace indicates some deeper serialization issue with regard to `program.dat` which I have not yet tried to debug. The local data for this test was last updated in 2019 in #22, so it should be current/valid I think.