### PR TITLE
Implement option to wait only until the downstream build is started

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerAction.java
@@ -29,23 +29,29 @@ class BuildTriggerAction extends InvisibleAction implements FoldableAction {
         final StepContext context;
 
         final boolean propagate;
+        final boolean waitForStart;
 
         /** Record of cancellation cause passed to {@link BuildTriggerStepExecution#stop}, if any. */
         @CheckForNull
         Throwable interruption;
 
-        Trigger(StepContext context, boolean propagate) {
+        Trigger(StepContext context, boolean propagate, boolean waitForStart) {
             this.context = context;
             this.propagate = propagate;
+            this.waitForStart = waitForStart;
+        }
+
+        Trigger(StepContext context, boolean propagate) {
+           this(context, propagate, false);
         }
 
     }
 
     private /* final */ List<Trigger> triggers;
 
-    BuildTriggerAction(StepContext context, boolean propagate) {
+    BuildTriggerAction(StepContext context, boolean propagate, boolean waitForStart) {
         triggers = new ArrayList<>();
-        triggers.add(new Trigger(context, propagate));
+        triggers.add(new Trigger(context, propagate, waitForStart));
     }
 
     private Object readResolve() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerAction.java
@@ -41,10 +41,6 @@ class BuildTriggerAction extends InvisibleAction implements FoldableAction {
             this.waitForStart = waitForStart;
         }
 
-        Trigger(StepContext context, boolean propagate) {
-           this(context, propagate, false);
-        }
-
     }
 
     private /* final */ List<Trigger> triggers;

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerAction.java
@@ -53,7 +53,7 @@ class BuildTriggerAction extends InvisibleAction implements FoldableAction {
     private Object readResolve() {
         if (triggers == null) {
             triggers = new ArrayList<>();
-            triggers.add(new Trigger(context, propagate != null ? propagate : /* old serialized record */ true));
+            triggers.add(new Trigger(context, propagate != null ? propagate : /* old serialized record */ true, false));
             context = null;
             propagate = null;
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java
@@ -54,6 +54,7 @@ public class BuildTriggerStep extends Step {
     private final String job;
     private List<ParameterValue> parameters;
     private boolean wait = true;
+    private boolean waitForStart = false;
     private boolean propagate = true;
     private Integer quietPeriod;
 
@@ -80,6 +81,14 @@ public class BuildTriggerStep extends Step {
 
     @DataBoundSetter public void setWait(boolean wait) {
         this.wait = wait;
+    }
+
+    public boolean getWaitForStart() {
+        return waitForStart;
+    }
+
+    @DataBoundSetter public void setWaitForStart(boolean waitForStart) {
+        this.waitForStart = waitForStart;
     }
 
     public Integer getQuietPeriod() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -71,7 +71,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
             throw new AbortException("No item named " + job + " found");
         }
         item.checkPermission(Item.BUILD);
-        if (step.getWait() && !(item instanceof Job)) {
+        if ((step.getWait() || step.getWaitForStart()) && !(item instanceof Job)) {
             // TODO find some way of allowing ComputedFolders to hook into the listener code
             throw new AbortException("Waiting for non-job items is not supported");
         }
@@ -86,9 +86,9 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
 
             getContext().get(FlowNode.class).addAction(new LabelAction(Messages.BuildTriggerStepExecution_building_(project.getFullDisplayName())));
 
-            if (step.getWait()) {
+            if (step.getWait() || step.getWaitForStart()) {
                 StepContext context = getContext();
-                actions.add(new BuildTriggerAction(context, step.isPropagate()));
+                actions.add(new BuildTriggerAction(context, step.isPropagate(), step.getWaitForStart()));
                 LOGGER.log(Level.FINER, "scheduling a build of {0} from {1}", new Object[]{project, context});
             }
 
@@ -111,9 +111,9 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
             Queue.Task task = (Queue.Task) item;
             getContext().get(TaskListener.class).getLogger().println("Scheduling item: " + ModelHyperlinkNote.encodeTo(item));
             getContext().get(FlowNode.class).addAction(new LabelAction(Messages.BuildTriggerStepExecution_building_(task.getFullDisplayName())));
-            if (step.getWait()) {
+            if (step.getWait() || step.getWaitForStart()) {
                 StepContext context = getContext();
-                actions.add(new BuildTriggerAction(context, step.isPropagate()));
+                actions.add(new BuildTriggerAction(context, step.isPropagate(), step.getWaitForStart()));
                 LOGGER.log(Level.FINER, "scheduling a build of {0} from {1}", new Object[]{task, context});
             }
 
@@ -144,7 +144,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
                     : item.getClass().getName())
                     + " which is not something that can be built");
         }
-        if (step.getWait()) {
+        if (step.getWait() || step.getWaitForStart()) {
             return false;
         } else {
             getContext().onSuccess(null);

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/config.jelly
@@ -32,6 +32,9 @@ THE SOFTWARE.
     <f:entry field="wait">
         <f:checkbox default="true" title="Wait for completion"/>
     </f:entry>
+    <f:entry field="waitForStart">
+        <f:checkbox default="false" title="Wait until the build starts"/>
+    </f:entry>
     <f:entry field="propagate">
         <f:checkbox default="true" title="Propagate errors"/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help-waitForStart.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/help-waitForStart.html
@@ -1,0 +1,4 @@
+<div>
+    If true, the pipeline will wait for the downstream build to start before jumping to the next step. Defaults to false.
+    Overrides the value of <code>wait</code>.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -411,6 +411,13 @@ public class BuildTriggerStepTest {
         j.buildAndAssertSuccess(us);
     }
 
+    @Test public void waitForStart() throws Exception {
+        j.createFreeStyleProject("ds").getBuildersList().add(new FailureBuilder());
+        WorkflowJob us = j.jenkins.createProject(WorkflowJob.class, "us");
+        us.setDefinition(new CpsFlowDefinition("build job: 'ds', waitForStart: true", true));
+        j.assertLogContains("Starting building:", j.buildAndAssertSuccess(us));
+    }
+
     @Test public void rejectedStart() throws Exception {
         j.createFreeStyleProject("ds");
         WorkflowJob us = j.jenkins.createProject(WorkflowJob.class, "us");


### PR DESCRIPTION
Add a new option `waitForStart` to the `build` step. The `waitForStart` option changes the behavior of the `build` step to block until the downstream build is started and a valid `RunWrapper` can be returned.

Implements https://issues.jenkins.io/browse/JENKINS-60849

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
