### PR TITLE
Mark pipeline build step with the downstream build result

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
@@ -11,6 +11,8 @@ import hudson.model.listeners.RunListener;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.util.Timer;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
@@ -50,6 +52,9 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
 
             try {
                 stepContext.get(TaskListener.class).getLogger().println("Build " + ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName()) + " completed: " + result.toString());
+                if (result != Result.SUCCESS) {
+                    stepContext.get(FlowNode.class).addOrReplaceAction(new WarningAction(result));
+                }
             }  catch (Exception e) {
                 LOGGER.log(Level.WARNING, null, e);
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
@@ -41,16 +41,27 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
     @Override
     public void onCompleted(Run<?,?> run, @NonNull TaskListener listener) {
         for (BuildTriggerAction.Trigger trigger : BuildTriggerAction.triggersFor(run)) {
-            LOGGER.log(Level.FINE, "completing {0} for {1}", new Object[] {run, trigger.context});
-            if (!trigger.propagate || run.getResult() == Result.SUCCESS) {
+            StepContext stepContext = trigger.context;
+            LOGGER.log(Level.FINE, "completing {0} for {1}", new Object[] {run, stepContext});
+            Result result = run.getResult();
+            if (result == null) { /* probably impossible */
+                result = Result.FAILURE;
+            }
+
+            try {
+                stepContext.get(TaskListener.class).getLogger().println("Build " + ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName()) + " completed: " + result.toString());
+            }  catch (Exception e) {
+                LOGGER.log(Level.WARNING, null, e);
+            }
+
+            if (!trigger.propagate || result == Result.SUCCESS) {
                 if (trigger.interruption == null) {
-                    trigger.context.onSuccess(new RunWrapper(run, false));
+                    stepContext.onSuccess(new RunWrapper(run, false));
                 } else {
-                    trigger.context.onFailure(trigger.interruption);
+                    stepContext.onFailure(trigger.interruption);
                 }
             } else {
-                Result result = run.getResult();
-                trigger.context.onFailure(new FlowInterruptedException(result != null ? result : /* probably impossible */ Result.FAILURE, false, new DownstreamFailureCause(run)));
+                stepContext.onFailure(new FlowInterruptedException(result, false, new DownstreamFailureCause(run)));
             }
         }
         run.removeActions(BuildTriggerAction.class);

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -58,6 +58,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
@@ -84,6 +86,7 @@ import org.jvnet.hudson.test.MockQueueItemAuthenticator;
 import org.jvnet.hudson.test.SleepBuilder;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.UnstableBuilder;
 import org.jvnet.hudson.test.recipes.LocalData;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -91,6 +94,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class BuildTriggerStepTest {
 
@@ -123,6 +127,44 @@ public class BuildTriggerStepTest {
         j.assertBuildStatus(Result.FAILURE, us.scheduleBuild2(0));
         us.setDefinition(new CpsFlowDefinition("echo \"ds.result=${build(job: 'ds', propagate: false).result}\"", true));
         j.assertLogContains("ds.result=FAILURE", j.buildAndAssertSuccess(us));
+    }
+
+    @Issue("JENKINS-70623")
+    @Test public void failingBuildWithWarningAction() throws Exception {
+        j.createFreeStyleProject("ds").getBuildersList().add(new FailureBuilder());
+        WorkflowJob upstream = j.jenkins.createProject(WorkflowJob.class, "us");
+        upstream.setDefinition(new CpsFlowDefinition("build(job: 'ds', propagate: false)", true));
+        WorkflowRun lastUpstream = j.buildAndAssertSuccess(upstream);
+        j.assertLogContains("completed: FAILURE", lastUpstream);
+        FlowNode buildTriggerNode = findFirstNodeWithDescriptor(lastUpstream.getExecution(), BuildTriggerStep.DescriptorImpl.class);
+        WarningAction action = buildTriggerNode.getAction(WarningAction.class);
+        assertNotNull(action);
+        assertEquals(action.getResult(), Result.FAILURE);
+    }
+
+    @Issue("JENKINS-70623")
+    @Test public void unstableBuildWithWarningAction() throws Exception {
+        j.createFreeStyleProject("ds").getBuildersList().add(new UnstableBuilder());
+        WorkflowJob upstream = j.jenkins.createProject(WorkflowJob.class, "us");
+        upstream.setDefinition(new CpsFlowDefinition("build(job: 'ds', propagate: false)", true));
+        WorkflowRun lastUpstream = j.buildAndAssertSuccess(upstream);
+        j.assertLogContains("completed: UNSTABLE", lastUpstream);
+        FlowNode buildTriggerNode = findFirstNodeWithDescriptor(lastUpstream.getExecution(), BuildTriggerStep.DescriptorImpl.class);
+        WarningAction action = buildTriggerNode.getAction(WarningAction.class);
+        assertNotNull(action);
+        assertEquals(action.getResult(), Result.UNSTABLE);
+    }
+
+    @Issue("JENKINS-70623")
+    @Test public void successBuildNoWarningAction() throws Exception {
+        j.createFreeStyleProject("ds");
+        WorkflowJob upstream = j.jenkins.createProject(WorkflowJob.class, "us");
+        upstream.setDefinition(new CpsFlowDefinition("build(job: 'ds', propagate: false)", true));
+        WorkflowRun lastUpstream = j.buildAndAssertSuccess(upstream);
+        j.assertLogContains("completed: SUCCESS", lastUpstream);
+        FlowNode buildTriggerNode = findFirstNodeWithDescriptor(lastUpstream.getExecution(), BuildTriggerStep.DescriptorImpl.class);
+        WarningAction action = buildTriggerNode.getAction(WarningAction.class);
+        assertNull(action);
     }
 
     @Issue("JENKINS-60995")


### PR DESCRIPTION
When `wait: true` is set, add a `WarningAction` to the build step `FlowNode` when the downstream build isn't successful even when `propagate: false` is also set.

Also, log the build result when the downstream run completes.

Implements https://issues.jenkins.io/browse/JENKINS-70623

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
