### PR TITLE
Only add WarningAction when propagate: true

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
@@ -56,8 +56,10 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
 
                 try {
                     stepContext.get(TaskListener.class).getLogger().println("Build " + ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName()) + " completed: " + result.toString());
-                    if (result != Result.SUCCESS) {
-                        stepContext.get(FlowNode.class).addOrReplaceAction(new WarningAction(result));
+                    if (trigger.propagate) {
+                        if (result != Result.SUCCESS) {
+                            stepContext.get(FlowNode.class).addOrReplaceAction(new WarningAction(result));
+                        }
                     }
                 }  catch (Exception e) {
                     LOGGER.log(Level.WARNING, null, e);

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
@@ -56,10 +56,8 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
 
                 try {
                     stepContext.get(TaskListener.class).getLogger().println("Build " + ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName()) + " completed: " + result.toString());
-                    if (trigger.propagate) {
-                        if (result != Result.SUCCESS) {
-                            stepContext.get(FlowNode.class).addOrReplaceAction(new WarningAction(result));
-                        }
+                    if (trigger.propagate && result != Result.SUCCESS) {
+                        stepContext.get(FlowNode.class).addOrReplaceAction(new WarningAction(result));
                     }
                 }  catch (Exception e) {
                     LOGGER.log(Level.WARNING, null, e);

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -133,8 +133,8 @@ public class BuildTriggerStepTest {
     @Test public void failingBuildWithWarningAction() throws Exception {
         j.createFreeStyleProject("ds").getBuildersList().add(new FailureBuilder());
         WorkflowJob upstream = j.jenkins.createProject(WorkflowJob.class, "us");
-        upstream.setDefinition(new CpsFlowDefinition("build(job: 'ds', propagate: false)", true));
-        WorkflowRun lastUpstream = j.buildAndAssertSuccess(upstream);
+        upstream.setDefinition(new CpsFlowDefinition("build(job: 'ds')", true));
+        WorkflowRun lastUpstream = j.buildAndAssertStatus(Result.FAILURE, upstream);
         j.assertLogContains("completed: FAILURE", lastUpstream);
         FlowNode buildTriggerNode = findFirstNodeWithDescriptor(lastUpstream.getExecution(), BuildTriggerStep.DescriptorImpl.class);
         WarningAction action = buildTriggerNode.getAction(WarningAction.class);
@@ -146,8 +146,8 @@ public class BuildTriggerStepTest {
     @Test public void unstableBuildWithWarningAction() throws Exception {
         j.createFreeStyleProject("ds").getBuildersList().add(new UnstableBuilder());
         WorkflowJob upstream = j.jenkins.createProject(WorkflowJob.class, "us");
-        upstream.setDefinition(new CpsFlowDefinition("build(job: 'ds', propagate: false)", true));
-        WorkflowRun lastUpstream = j.buildAndAssertSuccess(upstream);
+        upstream.setDefinition(new CpsFlowDefinition("build(job: 'ds')", true));
+        WorkflowRun lastUpstream = j.buildAndAssertStatus(Result.UNSTABLE, upstream);
         j.assertLogContains("completed: UNSTABLE", lastUpstream);
         FlowNode buildTriggerNode = findFirstNodeWithDescriptor(lastUpstream.getExecution(), BuildTriggerStep.DescriptorImpl.class);
         WarningAction action = buildTriggerNode.getAction(WarningAction.class);
@@ -159,7 +159,7 @@ public class BuildTriggerStepTest {
     @Test public void successBuildNoWarningAction() throws Exception {
         j.createFreeStyleProject("ds");
         WorkflowJob upstream = j.jenkins.createProject(WorkflowJob.class, "us");
-        upstream.setDefinition(new CpsFlowDefinition("build(job: 'ds', propagate: false)", true));
+        upstream.setDefinition(new CpsFlowDefinition("build(job: 'ds')", true));
         WorkflowRun lastUpstream = j.buildAndAssertSuccess(upstream);
         j.assertLogContains("completed: SUCCESS", lastUpstream);
         FlowNode buildTriggerNode = findFirstNodeWithDescriptor(lastUpstream.getExecution(), BuildTriggerStep.DescriptorImpl.class);


### PR DESCRIPTION
Fix for https://issues.jenkins.io/browse/JENKINS-70844 which is a knock on from https://github.com/jenkinsci/pipeline-build-step-plugin/pull/107.

Looking at the implementation of `BuildCondition`s in declarative pipelines, any `WarningAction` attached to a node within a stage will trigger the `Unsuccessful` condition.  See [BuildCondition.java#L165](https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/a31cb3b80ef89014f1b4dc5a37ab514e470a3f94/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java#L165).

In order to maintain the previous behavior, only add the `WarningAction` when `propagte: true`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

