### PR TITLE
Mark pipeline waitForBuild step with the downstream build result

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildListener.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.workflow.support.steps.build;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.console.ModelHyperlinkNote;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -26,6 +27,7 @@ public class WaitForBuildListener extends RunListener<Run<?,?>> {
 
             Result result = run.getResult();
             try {
+                context.get(TaskListener.class).getLogger().println("Build " + ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName()) + " completed: " + result.toString());
                 if (result.isWorseThan(Result.SUCCESS)) {
                     context.get(FlowNode.class).addOrReplaceAction(new WarningAction(result));
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildListener.java
@@ -26,6 +26,9 @@ public class WaitForBuildListener extends RunListener<Run<?,?>> {
             LOGGER.log(Level.FINE, "completing {0} for {1}", new Object[] {run, context});
 
             Result result = run.getResult();
+            if (result == null) { /* probably impossible */
+                result = Result.FAILURE;
+            }
             try {
                 context.get(TaskListener.class).getLogger().println("Build " + ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName()) + " completed: " + result.toString());
                 if (action.propagate && result.isWorseThan(Result.SUCCESS)) {
@@ -38,7 +41,7 @@ public class WaitForBuildListener extends RunListener<Run<?,?>> {
             if (!action.propagate || result == Result.SUCCESS) {
                 context.onSuccess(new RunWrapper(run, false));
             } else {
-                context.onFailure(new FlowInterruptedException(result != null ? result : /* probably impossible */ Result.FAILURE, false, new DownstreamFailureCause(run)));
+                context.onFailure(new FlowInterruptedException(result, false, new DownstreamFailureCause(run)));
             }
         }
         run.removeActions(WaitForBuildAction.class);

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildListener.java
@@ -28,7 +28,7 @@ public class WaitForBuildListener extends RunListener<Run<?,?>> {
             Result result = run.getResult();
             try {
                 context.get(TaskListener.class).getLogger().println("Build " + ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName()) + " completed: " + result.toString());
-                if (result.isWorseThan(Result.SUCCESS)) {
+                if (action.propagate && result.isWorseThan(Result.SUCCESS)) {
                     context.get(FlowNode.class).addOrReplaceAction(new WarningAction(result));
                 }
             } catch (Exception e) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildListener.java
@@ -8,6 +8,8 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
@@ -21,10 +23,19 @@ public class WaitForBuildListener extends RunListener<Run<?,?>> {
         for (WaitForBuildAction action : run.getActions(WaitForBuildAction.class)) {
             StepContext context = action.context;
             LOGGER.log(Level.FINE, "completing {0} for {1}", new Object[] {run, context});
-            if (!action.propagate || run.getResult() == Result.SUCCESS) {
+
+            Result result = run.getResult();
+            try {
+                if (result.isWorseThan(Result.SUCCESS)) {
+                    context.get(FlowNode.class).addOrReplaceAction(new WarningAction(result));
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, null, e);
+            }
+
+            if (!action.propagate || result == Result.SUCCESS) {
                 context.onSuccess(new RunWrapper(run, false));
             } else {
-                Result result = run.getResult();
                 context.onFailure(new FlowInterruptedException(result != null ? result : /* probably impossible */ Result.FAILURE, false, new DownstreamFailureCause(run)));
             }
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepTest.java
@@ -6,18 +6,27 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.tasks.Builder;
 import hudson.util.DescribableList;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.FailureBuilder;
-import org.jvnet.hudson.test.SleepBuilder;
-import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.UnstableBuilder;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class WaitForBuildStepTest {
 
@@ -62,5 +71,37 @@ public class WaitForBuildStepTest {
         WorkflowJob us = j.jenkins.createProject(WorkflowJob.class, "us");
         us.setDefinition(new CpsFlowDefinition("waitForBuild runId: 'ds#1'", true));
         j.assertLogContains("is already complete", j.buildAndAssertSuccess(us));
+    }
+
+    @Issue("JENKINS-70983")
+    @Test public void waitForUnstableBuildWithWarningAction() throws Exception {
+        FreeStyleProject ds = j.createFreeStyleProject("ds");
+        DescribableList<Builder, Descriptor<Builder>> buildersList = ds.getBuildersList();
+        buildersList.add(new SleepBuilder(500));
+        buildersList.add(new UnstableBuilder());
+        WorkflowJob us = j.jenkins.createProject(WorkflowJob.class, "us");
+        us.setDefinition(new CpsFlowDefinition(
+            "def ds = build job: 'ds', waitForStart: true\n" +
+            "def dsRunId = \"${ds.getFullProjectName()}#${ds.getNumber()}\"\n" +
+            "def completeDs = waitForBuild runId: dsRunId\n" +
+            "echo \"'ds' completed with status ${completeDs.getResult()}\"", true));
+        j.assertLogContains("'ds' completed with status UNSTABLE", j.buildAndAssertSuccess(us));
+        WorkflowRun lastUpstreamRun = us.getLastBuild();
+        FlowNode buildTriggerNode = findFirstNodeWithDescriptor(lastUpstreamRun.getExecution(), WaitForBuildStep.DescriptorImpl.class);
+        WarningAction action = buildTriggerNode.getAction(WarningAction.class);
+        assertNotNull(action);
+        assertEquals(action.getResult(), Result.UNSTABLE);
+    }
+
+    private static FlowNode findFirstNodeWithDescriptor(FlowExecution execution, Class<WaitForBuildStep.DescriptorImpl> cls) {
+        for (FlowNode node : new FlowGraphWalker(execution)) {
+            if (node instanceof StepAtomNode) {
+                StepAtomNode stepAtomNode = (StepAtomNode) node;
+                if (cls.isInstance(stepAtomNode.getDescriptor())) {
+                    return stepAtomNode;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepTest.java
@@ -83,9 +83,12 @@ public class WaitForBuildStepTest {
         us.setDefinition(new CpsFlowDefinition(
             "def ds = build job: 'ds', waitForStart: true\n" +
             "def dsRunId = \"${ds.getFullProjectName()}#${ds.getNumber()}\"\n" +
-            "def completeDs = waitForBuild runId: dsRunId\n" +
-            "echo \"'ds' completed with status ${completeDs.getResult()}\"", true));
-        j.assertLogContains("'ds' completed with status UNSTABLE", j.buildAndAssertSuccess(us));
+            "try {\n" +
+            "    waitForBuild runId: dsRunId, propagate: true\n" +
+            "} finally {\n" +
+            "    echo \"'ds' completed with status ${ds.getResult()}\"\n" +
+            "}", true));
+        j.assertLogContains("'ds' completed with status UNSTABLE", j.buildAndAssertStatus(Result.UNSTABLE, us));
         WorkflowRun lastUpstreamRun = us.getLastBuild();
         FlowNode buildTriggerNode = findFirstNodeWithDescriptor(lastUpstreamRun.getExecution(), WaitForBuildStep.DescriptorImpl.class);
         WarningAction action = buildTriggerNode.getAction(WarningAction.class);


### PR DESCRIPTION
Add a WarningAction to the `waitForBuild` step FlowNode when the downstream build isn't successful.

Also, log the build result when the downstream run completes.

This is the `waitForBuild` step equivalent of https://github.com/jenkinsci/pipeline-build-step-plugin/pull/107.

Implements https://issues.jenkins.io/browse/JENKINS-70983

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
