### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep/config.jelly
@@ -45,16 +45,16 @@ THE SOFTWARE.
         <div id="params"/>
         <script>
             function loadParams() {
-                var div = $$('params');
-                new Ajax.Request('${descriptor.descriptorUrl}/parameters?job=' + encodeURIComponent($$('${jobFieldId}').value) + '&amp;context=${descriptor.contextEncoded}', {
-                    method : 'get',
-                    onSuccess : function(x) {
-                        div.innerHTML = x.responseText;
-                        Behaviour.applySubtree(div);
-                    },
-                    onFailure : function(x) {
-                        div.innerHTML = "<b>ERROR</b>: Failed to load parameter definitions: " + x.statusText;
-                    }
+                var div = document.getElementById('params');
+                fetch('${descriptor.descriptorUrl}/parameters?job=' + encodeURIComponent(document.getElementById('${jobFieldId}').value) + '&amp;context=${descriptor.contextEncoded}').then((rsp) => {
+                    rsp.text().then((responseText) => {
+                        if (rsp.ok) {
+                            div.innerHTML = responseText;
+                            Behaviour.applySubtree(div);
+                        } else {
+                            div.innerHTML = "<b>ERROR</b>: Failed to load parameter definitions: " + rsp.statusText;
+                        }
+                    });
                 });
             }
         </script>


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I installed this plugin on a custom build of Jenkins that had Prototype ripped out (a local project branch), went to the Pipeline snippets page, selected the build step, selected a job that had parameters, and verified in the debugger that the changed lines were executed and that the parameters showed up correctly.