### PR TITLE
Make `BuildTriggerListener` wait for `onFinalized`, not just `onCompleted`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.workflow.support.steps.build;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.console.ModelHyperlinkNote;
@@ -44,7 +43,7 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
     }
 
     @Override
-    public void onCompleted(Run<?,?> run, @NonNull TaskListener listener) {
+    public void onFinalized(Run<?,?> run) {
         for (BuildTriggerAction.Trigger trigger : BuildTriggerAction.triggersFor(run)) {
             if (!trigger.waitForStart) {
                 StepContext stepContext = trigger.context;


### PR DESCRIPTION
As a result of https://github.com/jenkinsci/jenkins-test-harness/pull/198 we see occasionally flakes in PCT

```
java.io.IOException: …/pipeline-build-step-plugin/target/tmp/j h17881095753960446783/jobs/dir1/jobs/downstream/builds/1/build.xml
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:144)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.dispose(TemporaryDirectoryAllocator.java:99)
	at org.jvnet.hudson.test.TestEnvironment.dispose(TestEnvironment.java:84)
	at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:525)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:626)
	at …
Caused by: java.nio.file.DirectoryNotEmptyException: …/pipeline-build-step-plugin/target/tmp/j h17881095753960446783/jobs/dir1/jobs/downstream/builds/1
	at java.base/sun.nio.fs.UnixFileSystemProvider.implDelete(UnixFileSystemProvider.java:247)
	at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
	at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:141)
	... 14 more
```

with stderr like this:

```
…
1.030 [id=192]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
1.145 [dir2/upstream #1] Started
1.145 [dir2/upstream #1] [Pipeline] Start of Pipeline
1.196 [dir1/downstream #1] Started by upstream project "dir2/upstream" build number 1
1.196 [dir1/downstream #1] Running as SYSTEM
1.196 [dir1/downstream #1] Building in workspace …/pipeline-build-step-plugin/target/tmp/j h17881095753960446783/workspace/dir1/downstream
1.196 [dir2/upstream #1] [Pipeline] build
1.196 [dir2/upstream #1] Scheduling project: dir1 » downstream
1.196 [dir2/upstream #1] Starting building: dir1 » downstream #1
1.246 [dir1/downstream #1] Sleeping 1ms
1.247 [dir2/upstream #1] Build dir1 » downstream #1 completed: SUCCESS
1.247 [dir2/upstream #1] [Pipeline] End of Pipeline
1.247 [dir2/upstream #1] Finished: SUCCESS
1.254 [id=169]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
1.262 [id=169]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
1.312 [dir1/downstream #1] Finished: SUCCESS
1.311 [id=169]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting …/pipeline-build-step-plugin/target/tmp/j h17881095753960446783
```

You can see that the downstream build is actually finishing after the test has completed and when `JenkinsRule` is trying to clean up. I cannot reproduce this locally but suspect that this is because the listener used by the upstream step is only waiting for the downstream build to be nearly complete. Probably best to wait for it to be fully complete, which should also prevent the test flake.
