### PR TITLE
[JENKINS-71961] Fix waitForBuild Step does not abort downstream build when upstream job aborted

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildListener.java
@@ -1,12 +1,14 @@
 package org.jenkinsci.plugins.workflow.support.steps.build;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.AbortException;
 import hudson.Extension;
 import hudson.console.ModelHyperlinkNote;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
+import jenkins.util.Timer;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jenkinsci.plugins.workflow.actions.WarningAction;
@@ -45,5 +47,12 @@ public class WaitForBuildListener extends RunListener<Run<?,?>> {
             }
         }
         run.removeActions(WaitForBuildAction.class);
+    }
+
+    @Override
+    public void onDeleted(final Run<?,?> run) {
+        for (WaitForBuildAction action : run.getActions(WaitForBuildAction.class)) {
+            Timer.get().submit(() -> action.context.onFailure(new AbortException(run.getFullDisplayName() + " was deleted")));
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildListener.java
@@ -20,7 +20,7 @@ public class WaitForBuildListener extends RunListener<Run<?,?>> {
     private static final Logger LOGGER = Logger.getLogger(WaitForBuildListener.class.getName());
 
     @Override
-    public void onCompleted(Run<?,?> run, @NonNull TaskListener listener) {
+    public void onFinalized(Run<?,?> run) {
         for (WaitForBuildAction action : run.getActions(WaitForBuildAction.class)) {
             StepContext context = action.context;
             LOGGER.log(Level.FINE, "completing {0} for {1}", new Object[] {run, context});

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStep.java
@@ -24,6 +24,7 @@ public class WaitForBuildStep extends Step {
 
     private final String runId;
     private boolean propagate = false;
+    private boolean propagateAbort = false;
 
     @DataBoundConstructor
     public WaitForBuildStep(String runId) {
@@ -40,6 +41,14 @@ public class WaitForBuildStep extends Step {
 
     @DataBoundSetter public void setPropagate(boolean propagate) {
         this.propagate = propagate;
+    }
+
+    public boolean isPropagateAbort() {
+        return propagateAbort;
+    }
+
+    @DataBoundSetter public void setPropagateAbort(boolean propagateAbort) {
+        this.propagateAbort = propagateAbort;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepExecution.java
@@ -3,16 +3,26 @@ package org.jenkinsci.plugins.workflow.support.steps.build;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.console.ModelHyperlinkNote;
+import hudson.model.Computer;
+import hudson.model.Executor;
+import hudson.model.Queue;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class WaitForBuildStepExecution extends AbstractStepExecutionImpl {
 
     private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = Logger.getLogger(WaitForBuildStepExecution.class.getName());
 
     private final transient WaitForBuildStep step;
 
@@ -53,6 +63,53 @@ public class WaitForBuildStepExecution extends AbstractStepExecutionImpl {
             }
             return true;
         }
+    }
+
+    @Override
+    public void stop(@NonNull Throwable cause) throws Exception {
+        StepContext context = getContext();
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins == null) {
+            context.onFailure(cause);
+            return;
+        }
+
+        boolean interrupted = false;
+
+        // if there's any in-progress build already, abort that.
+        // when the build is actually aborted, WaitForBuildListener will take notice and report the failure,
+        // so this method shouldn't call getContext().onFailure()
+        for (Computer c : jenkins.getComputers()) {
+            for (Executor e : c.getExecutors()) {
+                interrupted |= maybeInterrupt(e, cause, context);
+            }
+            for (Executor e : c.getOneOffExecutors()) {
+                interrupted |= maybeInterrupt(e, cause, context);
+            }
+        }
+
+        if (!interrupted) {
+            super.stop(cause);
+        }
+    }
+
+    private static boolean maybeInterrupt(Executor e, Throwable cause, StepContext context) {
+        boolean interrupted = false;
+        Queue.Executable exec = e.getCurrentExecutable();
+        if (exec instanceof Run) {
+            for(WaitForBuildAction waitForBuildAction : ((Run<?, ?>) exec).getActions(WaitForBuildAction.class)) {
+                if (waitForBuildAction.context.equals(context)) {
+                    e.interrupt(Result.ABORTED, new BuildTriggerCancelledCause(cause));
+                    try {
+                        ((Run<?, ?>) exec).save();
+                    } catch (IOException x) {
+                        LOGGER.log(Level.WARNING, "failed to save interrupt cause on " + exec, x);
+                    }
+                    interrupted = true;
+                }
+            }
+        }
+        return interrupted;
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepExecution.java
@@ -80,10 +80,7 @@ public class WaitForBuildStepExecution extends AbstractStepExecutionImpl {
         // when the build is actually aborted, WaitForBuildListener will take notice and report the failure,
         // so this method shouldn't call getContext().onFailure()
         for (Computer c : jenkins.getComputers()) {
-            for (Executor e : c.getExecutors()) {
-                interrupted |= maybeInterrupt(e, cause, context);
-            }
-            for (Executor e : c.getOneOffExecutors()) {
+            for (Executor e : c.getAllExecutors()) {
                 interrupted |= maybeInterrupt(e, cause, context);
             }
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepTest.java
@@ -141,7 +141,7 @@ public class WaitForBuildStepTest {
         us.setDefinition(new CpsFlowDefinition(
             "def ds = build job: 'ds', waitForStart: true\n" +
             "def dsRunId = \"${ds.getFullProjectName()}#${ds.getNumber()}\"\n" +
-            "def completeDs = waitForBuild runId: dsRunId, propagate: true\n" +
+            "def completeDs = waitForBuild runId: dsRunId, propagate: true, propagateAbort: true\n" +
             "echo \"'ds' completed with status ${completeDs.getResult()}\"", true));
 
         QueueTaskFuture<WorkflowRun> q = us.scheduleBuild2(0);

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepTest.java
@@ -51,6 +51,7 @@ public class WaitForBuildStepTest {
 
         // signal the downstream run to complete after it has been waited on
         WorkflowRun dsRun = ds.getBuildByNumber(1);
+        SemaphoreStep.waitForStart("wait/1", dsRun);
         waitForWaitForBuildAction(dsRun);
         SemaphoreStep.success("wait/1", true);
 
@@ -77,8 +78,8 @@ public class WaitForBuildStepTest {
         SemaphoreStep.waitForStart("scheduled/1", usRun);
         SemaphoreStep.success("scheduled/1", true);
 
-        // signal the downstream run to complete after it's been waited on
-        WorkflowRun dsRun = ds.getLastBuild();
+        // signal the downstream run to complete after it has been waited on
+        WorkflowRun dsRun = ds.getBuildByNumber(1);
         waitForWaitForBuildAction(dsRun);
         SemaphoreStep.success("wait/1", true);
 
@@ -137,8 +138,8 @@ public class WaitForBuildStepTest {
         SemaphoreStep.waitForStart("scheduled/1", usRun);
         SemaphoreStep.success("scheduled/1", true);
 
-        // signal the downstream run to complete after being waited on
-        WorkflowRun dsRun = ds.getLastBuild();
+        // signal the downstream run to complete after it has been waited on
+        WorkflowRun dsRun = ds.getBuildByNumber(1);
         waitForWaitForBuildAction(dsRun);
         SemaphoreStep.success("wait/1", true);
 


### PR DESCRIPTION
Implemented `stop()` method in `WaitForBuildStepExecution` so aborts can be propagated from the upstream job to downstream job that is being waited on.

Fix for https://issues.jenkins.io/browse/JENKINS-71961.

### Testing done

Add two new test cases to `WaitForBuildStepTest`:
- `abortBuild()`: validates that when the downstream job being waited on is aborted that the upstream job will be aborted too.
- `interruptFlow()`: validates that when the upstream job aborted then downstream job being waited on will be aborted too.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
