### PR TITLE
Store `DownstreamBuildAction` on `Run` instead of `FlowNode` for consistent persistence even on completed builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.387.x</artifactId>
-                <version>2143.ve4c3c9ec790a</version>
+                <version>2543.vfb_1a_5fb_9496d</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -90,16 +90,12 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
             <scope>test</scope>
-            <!-- TODO: Remove version declaration when workflow-cps plugin 3691.v28b_14c465a_b_b_ or newer is in plugin BOM -->
-            <version>3691.v28b_14c465a_b_b_</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
             <classifier>tests</classifier>
             <scope>test</scope>
-            <!-- TODO: Remove version declaration when workflow-cps plugin 3691.v28b_14c465a_b_b_ or newer is in plugin BOM -->
-            <version>3691.v28b_14c465a_b_b_</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -151,8 +147,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
             <scope>test</scope>
-            <!-- TODO: Remove version declaration when git plugin 5.1.0 or newer is in plugin BOM -->
-            <version>5.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerListener.java
@@ -106,13 +106,8 @@ public class BuildTriggerListener extends RunListener<Run<?,?>>{
                             LOGGER.log(Level.FINE, () -> "Unable to update DownstreamBuildAction for " + upstream + " node " + buildUpstreamCause.getNodeId());
                             continue;
                         }
-                        DownstreamBuildAction downstreamAction = node.getPersistentAction(DownstreamBuildAction.class);
-                        if (downstreamAction == null) {
-                            // Should only happen for builds already in the queue when this plugin is updated to include DownstreamBuildAction.
-                            downstreamAction = new DownstreamBuildAction(run.getParent());
-                            node.addAction(downstreamAction);
-                        }
-                        downstreamAction.setBuild(run);
+                        DownstreamBuildAction action = new DownstreamBuildAction(run);
+                        node.addOrReplaceAction(action);
                         run.save();
                     } catch (IOException e) {
                         LOGGER.log(Level.FINE, e, () -> "Unable to update DownstreamBuildAction for " + upstream + " node " + buildUpstreamCause.getNodeId());

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -66,8 +66,8 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
     @Override
     public boolean start() throws Exception {
         String job = step.getJob();
-        Run<?, ?> run = getContext().get(Run.class);
-        Item item = Jenkins.get().getItem(job, run.getParent(), Item.class);
+        Run<?, ?> upstream = getContext().get(Run.class);
+        Item item = Jenkins.get().getItem(job, upstream.getParent(), Item.class);
         if (item == null) {
             throw new AbortException("No item named " + job + " found");
         }
@@ -78,11 +78,11 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
         }
 
         FlowNode node = getContext().get(FlowNode.class);
-        run.addAction(new DownstreamBuildAction(node.getId(), item));
+        DownstreamBuildAction.getOrCreate(upstream, node.getId(), item);
 
         List<Action> actions = new ArrayList<>();
-        actions.add(new CauseAction(new BuildUpstreamCause(getContext().get(FlowNode.class), run)));
-        actions.add(new BuildUpstreamNodeAction(node, run));
+        actions.add(new CauseAction(new BuildUpstreamCause(getContext().get(FlowNode.class), upstream)));
+        actions.add(new BuildUpstreamNodeAction(node, upstream));
 
         if (item instanceof ParameterizedJobMixIn.ParameterizedJob) {
             final ParameterizedJobMixIn.ParameterizedJob project = (ParameterizedJobMixIn.ParameterizedJob) item;

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/DownstreamBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/DownstreamBuildAction.java
@@ -6,26 +6,26 @@ import hudson.model.InvisibleAction;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Run;
-import org.jenkinsci.plugins.workflow.actions.PersistentAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.springframework.security.access.AccessDeniedException;
 
 /**
- * Tracks the downstream build triggered by the {@code build} step.
+ * Tracks a downstream build triggered by the {@code build} step, as well as the {@link FlowNode#getId} of the step.
  *
  * @see BuildUpstreamCause
  */
-public final class DownstreamBuildAction extends InvisibleAction implements PersistentAction {
+public final class DownstreamBuildAction extends InvisibleAction {
+    private final String flowNodeId;
     private final String jobFullName;
-    private final Integer buildNumber;
+    private Integer buildNumber;
 
-    DownstreamBuildAction(Item job) {
+    DownstreamBuildAction(@NonNull String flowNodeId, @NonNull Item job) {
+        this.flowNodeId = flowNodeId;
         this.jobFullName = job.getFullName();
-        this.buildNumber = null;
     }
 
-    DownstreamBuildAction(Run<?, ?> run) {
-        this.jobFullName = run.getParent().getFullName();
-        this.buildNumber = run.getNumber();
+    public @NonNull String getFlowNodeId() {
+        return flowNodeId;
     }
 
     public @NonNull String getJobFullName() {
@@ -50,5 +50,9 @@ public final class DownstreamBuildAction extends InvisibleAction implements Pers
             return null;
         }
         return Run.fromExternalizableId(jobFullName + '#' + buildNumber);
+    }
+
+    void setBuild(@NonNull Run<?, ?> run) {
+        this.buildNumber = run.getNumber();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/DownstreamBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/DownstreamBuildAction.java
@@ -16,10 +16,16 @@ import org.springframework.security.access.AccessDeniedException;
  */
 public final class DownstreamBuildAction extends InvisibleAction implements PersistentAction {
     private final String jobFullName;
-    private Integer buildNumber;
+    private final Integer buildNumber;
 
     DownstreamBuildAction(Item job) {
         this.jobFullName = job.getFullName();
+        this.buildNumber = null;
+    }
+
+    DownstreamBuildAction(Run<?, ?> run) {
+        this.jobFullName = run.getParent().getFullName();
+        this.buildNumber = run.getNumber();
     }
 
     public @NonNull String getJobFullName() {
@@ -44,9 +50,5 @@ public final class DownstreamBuildAction extends InvisibleAction implements Pers
             return null;
         }
         return Run.fromExternalizableId(jobFullName + '#' + buildNumber);
-    }
-
-    void setBuild(Run<?, ?> build) {
-        this.buildNumber = build.getNumber();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/DownstreamBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/DownstreamBuildAction.java
@@ -6,53 +6,80 @@ import hudson.model.InvisibleAction;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Run;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.springframework.security.access.AccessDeniedException;
 
 /**
- * Tracks a downstream build triggered by the {@code build} step, as well as the {@link FlowNode#getId} of the step.
+ * Tracks downstream builds triggered by the {@code build} step, as well as the {@link FlowNode#getId} of the step.
  *
  * @see BuildUpstreamCause
  */
 public final class DownstreamBuildAction extends InvisibleAction {
-    private final String flowNodeId;
-    private final String jobFullName;
-    private Integer buildNumber;
+    private final Map<String, DownstreamBuild> downstreamBuilds = new LinkedHashMap<>();
 
-    DownstreamBuildAction(@NonNull String flowNodeId, @NonNull Item job) {
-        this.flowNodeId = flowNodeId;
-        this.jobFullName = job.getFullName();
-    }
-
-    public @NonNull String getFlowNodeId() {
-        return flowNodeId;
-    }
-
-    public @NonNull String getJobFullName() {
-        return jobFullName;
-    }
-
-    /**
-     * Get the build number of the downstream build, or {@code null} if the downstream build has not yet started or the queue item was cancelled.
-     */
-    public @CheckForNull Integer getBuildNumber() {
-        return buildNumber;
-    }
-
-    /**
-     * Load the downstream build, if it has started and still exists.
-     * <p>Loading builds indiscriminately will affect controller performance, so use this carefully. If you only need
-     * to know whether the build started at one point, use {@link #getBuildNumber}.
-     * @throws AccessDeniedException as per {@link ItemGroup#getItem}
-     */
-    public @CheckForNull Run<?, ?> getBuild() throws AccessDeniedException {
-        if (buildNumber == null) {
-            return null;
+    public static @NonNull DownstreamBuild getOrCreate(@NonNull Run<?, ?> run, @NonNull String flowNodeId, @NonNull Item job) {
+        DownstreamBuildAction downstreamBuildAction;
+        synchronized (DownstreamBuildAction.class) {
+            downstreamBuildAction = run.getAction(DownstreamBuildAction.class);
+            if (downstreamBuildAction == null) {
+                downstreamBuildAction = new DownstreamBuildAction();
+                run.addAction(downstreamBuildAction);
+            }
         }
-        return Run.fromExternalizableId(jobFullName + '#' + buildNumber);
+        return downstreamBuildAction.getOrAddDownstreamBuild(flowNodeId, job);
     }
 
-    void setBuild(@NonNull Run<?, ?> run) {
-        this.buildNumber = run.getNumber();
+    public synchronized @CheckForNull DownstreamBuild getDownstreamBuild(@NonNull String flowNodeId) {
+        return downstreamBuilds.get(flowNodeId);
+    }
+
+    public synchronized @NonNull Map<String, DownstreamBuild> getDownstreamBuilds() {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(downstreamBuilds));
+    }
+
+    private synchronized @NonNull DownstreamBuild getOrAddDownstreamBuild(@NonNull String flowNodeId, @NonNull Item job) {
+        var downstreamBuild = new DownstreamBuild(job);
+        var existing = downstreamBuilds.putIfAbsent(flowNodeId, downstreamBuild);
+        return existing == null ? downstreamBuild : existing;
+    }
+
+    public static final class DownstreamBuild {
+        private final String jobFullName;
+        private Integer buildNumber;
+
+        DownstreamBuild(@NonNull Item job) {
+            this.jobFullName = job.getFullName();
+        }
+
+        public @NonNull String getJobFullName() {
+            return jobFullName;
+        }
+
+        /**
+         * Get the build number of the downstream build, or {@code null} if the downstream build has not yet started or the queue item was cancelled.
+         */
+        public @CheckForNull Integer getBuildNumber() {
+            return buildNumber;
+        }
+
+        /**
+         * Load the downstream build, if it has started and still exists.
+         * <p>Loading builds indiscriminately will affect controller performance, so use this carefully. If you only need
+         * to know whether the build started at one point, use {@link #getBuildNumber}.
+         * @throws AccessDeniedException as per {@link ItemGroup#getItem}
+         */
+        public @CheckForNull Run<?, ?> getBuild() throws AccessDeniedException {
+            if (buildNumber == null) {
+                return null;
+            }
+            return Run.fromExternalizableId(jobFullName + '#' + buildNumber);
+        }
+
+        void setBuild(@NonNull Run<?, ?> run) {
+            this.buildNumber = run.getNumber();
+        }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepRestartTest.java
@@ -2,25 +2,35 @@ package org.jenkinsci.plugins.workflow.support.steps.build;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Label;
 import hudson.model.Queue;
 import hudson.model.Result;
+import hudson.model.Run;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsSessionRule;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Vivek Pandey
  */
-public class BuildTriggerStepRestartTest extends Assert {
+public class BuildTriggerStepRestartTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public JenkinsSessionRule sessions = new JenkinsSessionRule();
@@ -62,6 +72,43 @@ public class BuildTriggerStepRestartTest extends Assert {
         });
 
         sessions.then(j -> j.jenkins.getItemByFullName("test1", FreeStyleProject.class).getBuildByNumber(1).delete());
+    }
+
+    @Test
+    public void downstreamBuildAction() throws Throwable {
+        sessions.then(j -> {
+            FreeStyleProject downstream = j.createFreeStyleProject("downstream");
+            downstream.setAssignedLabel(Label.parseExpression("agent"));
+            WorkflowJob upstream = j.jenkins.createProject(WorkflowJob.class, "upstream");
+            upstream.setDefinition(new CpsFlowDefinition("build(job: 'downstream', wait: false)", true));
+            WorkflowRun upstreamRun = j.buildAndAssertSuccess(upstream);
+            // Check action while the build is still in the queue.
+            String buildStepId = BuildTriggerStepTest.findFirstNodeWithDescriptor(upstreamRun.getExecution(), BuildTriggerStep.DescriptorImpl.class).getId();
+            FlowNode node = upstreamRun.getExecution().getNode(buildStepId);
+            DownstreamBuildAction action = node.getAction(DownstreamBuildAction.class);
+            assertThat(action.getJobFullName(), equalTo(downstream.getFullName()));
+            assertThat(action.getBuildNumber(), nullValue());
+            assertThat(action.getBuild(), nullValue());
+            // Check again once the build has started.
+            j.createOnlineSlave(Label.parseExpression("agent"));
+            await().atMost(10, TimeUnit.SECONDS).until(() -> node.getAction(DownstreamBuildAction.class).getBuildNumber(), notNullValue());
+            Run<?, ?> downstreamRun = downstream.getLastBuild();
+            action = node.getAction(DownstreamBuildAction.class);
+            assertThat(action.getJobFullName(), equalTo(downstream.getFullName()));
+            assertThat(action.getBuildNumber(), equalTo(downstreamRun.getNumber()));
+            assertThat(action.getBuild(), equalTo(downstreamRun));
+            j.waitForCompletion(downstreamRun);
+        });
+        sessions.then(j -> {
+            FreeStyleProject downstream = j.jenkins.getItemByFullName("downstream", FreeStyleProject.class);
+            WorkflowJob upstream = j.jenkins.getItemByFullName("upstream", WorkflowJob.class);
+            WorkflowRun upstreamRun = upstream.getLastBuild();
+            String buildStepId = BuildTriggerStepTest.findFirstNodeWithDescriptor(upstreamRun.getExecution(), BuildTriggerStep.DescriptorImpl.class).getId();
+            DownstreamBuildAction action = upstreamRun.getExecution().getNode(buildStepId).getAction(DownstreamBuildAction.class);
+            assertThat(action.getJobFullName(), equalTo(downstream.getFullName()));
+            assertThat(action.getBuildNumber(), equalTo(downstream.getLastBuild().getNumber()));
+            assertThat(action.getBuild(), equalTo(downstream.getLastBuild()));
+        });
     }
 
     private static void assertFreeStyleProjectsInQueue(int count, JenkinsRule j) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -39,7 +39,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -89,7 +88,6 @@ import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.UnstableBuilder;
 import org.jvnet.hudson.test.recipes.LocalData;
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -208,7 +206,7 @@ public class BuildTriggerStepTest {
         assertEquals("There should be as many upstream causes as referenced upstream builds", numberOfUpstreamBuilds, ups.size());
     }
 
-    private static FlowNode findFirstNodeWithDescriptor(FlowExecution execution, Class<BuildTriggerStep.DescriptorImpl> cls) {
+    static FlowNode findFirstNodeWithDescriptor(FlowExecution execution, Class<BuildTriggerStep.DescriptorImpl> cls) {
         for (FlowNode node : new FlowGraphWalker(execution)) {
             if (node instanceof StepAtomNode) {
                 StepAtomNode stepAtomNode = (StepAtomNode) node;
@@ -241,27 +239,6 @@ public class BuildTriggerStepTest {
         BuildUpstreamNodeAction action = actions.get(0);
         assertEquals("correct upstreamRunId", action.getUpstreamRunId(), lastUpstreamRun.getExternalizableId());
         assertEquals("valid upstreamNodeId", buildTriggerNode, execution.getNode(action.getUpstreamNodeId()));
-    }
-
-    @Test public void downstreamBuildAction() throws Exception {
-        FreeStyleProject downstream = j.createFreeStyleProject("downstream");
-        downstream.setAssignedLabel(Label.parseExpression("agent"));
-        WorkflowJob upstream = j.jenkins.createProject(WorkflowJob.class, "upstream");
-        upstream.setDefinition(new CpsFlowDefinition("build(job: 'downstream', wait: false)", true));
-        WorkflowRun upstreamRun = j.buildAndAssertSuccess(upstream);
-        // Check action while the build is still in the queue.
-        String buildStepId = findFirstNodeWithDescriptor(upstreamRun.getExecution(), BuildTriggerStep.DescriptorImpl.class).getId();
-        DownstreamBuildAction action = upstreamRun.getExecution().getNode(buildStepId).getAction(DownstreamBuildAction.class);
-        assertThat(action.getJobFullName(), equalTo(downstream.getFullName()));
-        assertThat(action.getBuildNumber(), nullValue());
-        assertThat(action.getBuild(), nullValue());
-        // Check again once the build has started.
-        j.createOnlineSlave(Label.parseExpression("agent"));
-        Run<?, ?> downstreamRun = await().atMost(5, TimeUnit.SECONDS).until(downstream::getLastBuild, notNullValue());
-        assertThat(action.getJobFullName(), equalTo(downstream.getFullName()));
-        await().atMost(5, TimeUnit.SECONDS).until(action::getBuildNumber, equalTo(downstreamRun.getNumber()));
-        assertThat(action.getBuild(), equalTo(downstreamRun));
-        j.waitForCompletion(downstreamRun);
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
See https://github.com/jenkinsci/pipeline-build-step-plugin/pull/127#discussion_r1426716551.

CC @artmorse

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
