### PR TITLE
De-flake `BuildTriggerStepTest.waitForStart`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepTest.java
@@ -454,10 +454,12 @@ public class BuildTriggerStepTest {
     }
 
     @Test public void waitForStart() throws Exception {
-        j.createFreeStyleProject("ds").getBuildersList().add(new FailureBuilder());
+        FreeStyleProject ds = j.createFreeStyleProject("ds");
+        ds.getBuildersList().add(new FailureBuilder());
         WorkflowJob us = j.jenkins.createProject(WorkflowJob.class, "us");
         us.setDefinition(new CpsFlowDefinition("build job: 'ds', waitForStart: true", true));
         j.assertLogContains("Starting building:", j.buildAndAssertSuccess(us));
+        j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(ds.getLastBuild()));
     }
 
     @Test public void rejectedStart() throws Exception {


### PR DESCRIPTION
When running with `-Dorg.jvnet.hudson.test.RemainingActivityListener.fatal=true` I got the following error (fixed in this PR):

```
[ERROR] org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStepTest.waitForStart -- Time elapsed: 0.993 s <<< FAILURE!
java.lang.AssertionError: ds #1 still seems to be running, which could break deletion of log files or metadata
        at org.jvnet.hudson.test.RemainingActivityListener.onTearDown(RemainingActivityListener.java:62)
        at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:502)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:677)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```