### PR TITLE
Flakes in WaitForBuildStepTest

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepTest.java
@@ -173,6 +173,7 @@ public class WaitForBuildStepTest {
         SemaphoreStep.success("scheduled/1", true);
 
         WorkflowRun dsRun = ds.getBuildByNumber(1);
+        SemaphoreStep.waitForStart("wait/1", dsRun);
         waitForWaitForBuildAction(dsRun);
 
         // Abort the downstream build
@@ -201,6 +202,7 @@ public class WaitForBuildStepTest {
         SemaphoreStep.success("scheduled/1", true);
 
         WorkflowRun dsRun = ds.getBuildByNumber(1);
+        SemaphoreStep.waitForStart("wait/1", dsRun);
         waitForWaitForBuildAction(dsRun);
 
         // Abort the upstream build
@@ -229,6 +231,7 @@ public class WaitForBuildStepTest {
         SemaphoreStep.success("scheduled/1", true);
 
         WorkflowRun dsRun = ds.getBuildByNumber(1);
+        SemaphoreStep.waitForStart("wait/1", dsRun);
         waitForWaitForBuildAction(dsRun);
 
         // Abort the upstream build


### PR DESCRIPTION
Explicitly wait for the "wait" semaphore in downstream build, allowing the downstream build to go through full initialization.

Otherwise in some case you'd run into a timing issue where downstream build is not aborted as expected.

```
  10.218 [id=211]	WARNING	o.j.p.w.cps.CpsFlowExecution#saveOwner: Error persisting Run ds#1
java.nio.channels.ClosedByInterruptException
	at java.base/java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:199)
	at java.base/sun.nio.ch.FileChannelImpl.endBlocking(FileChannelImpl.java:171)
	at java.base/sun.nio.ch.FileChannelImpl.force(FileChannelImpl.java:472)
	at hudson.util.AtomicFileWriter.commit(AtomicFileWriter.java:234)
	at hudson.XmlFile.write(XmlFile.java:221)
	at org.jenkinsci.plugins.workflow.support.PipelineIOUtils.writeByXStream(PipelineIOUtils.java:30)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.save(WorkflowRun.java:1250)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.saveOwner(CpsFlowExecution.java:2124)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:622)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:335)
	at hudson.model.ResourceController.execute(ResourceController.java:101)
	at hudson.model.Executor.run(Executor.java:446)
 10.219 [us #1] [Pipeline] semaphore
  10.219 [us #1] [Pipeline] waitForBuild
  10.220 [us #1] Waiting for ds #1 to complete
  10.220 [ds #1] [Pipeline] Start of Pipeline
  10.241 [id=95]	INFO	o.j.p.w.t.s.SemaphoreStep$Execution#start: Blocking wait/1
  10.270 [ds #1] [Pipeline] semaphore
 180.002 [id=1]	WARNING	o.j.hudson.test.JenkinsRule$2#evaluate: Test timed out (after 180 seconds).
 [...]
```

@jglick 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
