### PR TITLE
Update LabelAction messages for Build and WaitForBuild steps

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -88,7 +88,11 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
             final ParameterizedJobMixIn.ParameterizedJob project = (ParameterizedJobMixIn.ParameterizedJob) item;
             getContext().get(TaskListener.class).getLogger().println("Scheduling project: " + ModelHyperlinkNote.encodeTo(project));
 
-            node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_building_(project.getFullDisplayName())));
+            if (!step.getWait() || step.getWaitForStart()) {
+                node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_scheduling_(project.getFullDisplayName())));
+            } else {
+                node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_building_(project.getFullDisplayName())));
+            }
 
             if (step.getWait() || step.getWaitForStart()) {
                 StepContext context = getContext();
@@ -115,6 +119,12 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
             Queue.Task task = (Queue.Task) item;
             getContext().get(TaskListener.class).getLogger().println("Scheduling item: " + ModelHyperlinkNote.encodeTo(item));
             node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_building_(task.getFullDisplayName())));
+            if (!step.getWait() || step.getWaitForStart()) {
+                node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_scheduling_(task.getFullDisplayName())));
+            } else {
+                node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_building_(task.getFullDisplayName())));    
+            }
+
             if (step.getWait() || step.getWaitForStart()) {
                 StepContext context = getContext();
                 actions.add(new BuildTriggerAction(context, step.isPropagate(), step.getWaitForStart()));

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -118,7 +118,6 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
             }
             Queue.Task task = (Queue.Task) item;
             getContext().get(TaskListener.class).getLogger().println("Scheduling item: " + ModelHyperlinkNote.encodeTo(item));
-            node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_building_(task.getFullDisplayName())));
             if (!step.getWait() || step.getWaitForStart()) {
                 node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_scheduling_(task.getFullDisplayName())));
             } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStepExecution.java
@@ -89,7 +89,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
             getContext().get(TaskListener.class).getLogger().println("Scheduling project: " + ModelHyperlinkNote.encodeTo(project));
 
             if (!step.getWait() || step.getWaitForStart()) {
-                node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_scheduling_(project.getFullDisplayName())));
+                node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_scheduling(project.getFullDisplayName())));
             } else {
                 node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_building_(project.getFullDisplayName())));
             }
@@ -119,7 +119,7 @@ public class BuildTriggerStepExecution extends AbstractStepExecutionImpl {
             Queue.Task task = (Queue.Task) item;
             getContext().get(TaskListener.class).getLogger().println("Scheduling item: " + ModelHyperlinkNote.encodeTo(item));
             if (!step.getWait() || step.getWaitForStart()) {
-                node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_scheduling_(task.getFullDisplayName())));
+                node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_scheduling(task.getFullDisplayName())));
             } else {
                 node.addAction(new LabelAction(Messages.BuildTriggerStepExecution_building_(task.getFullDisplayName())));    
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepExecution.java
@@ -10,6 +10,9 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
+
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -38,6 +41,9 @@ public class WaitForBuildStepExecution extends AbstractStepExecutionImpl {
         if (run == null) {
             throw new AbortException("No build exists with runId " + step.getRunId());
         }
+
+        FlowNode node = getContext().get(FlowNode.class);
+        node.addAction(new LabelAction(Messages.WaitForBuildStepExecution_waitfor_(step.getRunId())));
 
         String runHyperLink = ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName());
         TaskListener taskListener = getContext().get(TaskListener.class);

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/WaitForBuildStepExecution.java
@@ -43,7 +43,7 @@ public class WaitForBuildStepExecution extends AbstractStepExecutionImpl {
         }
 
         FlowNode node = getContext().get(FlowNode.class);
-        node.addAction(new LabelAction(Messages.WaitForBuildStepExecution_waitfor_(step.getRunId())));
+        node.addAction(new LabelAction(Messages.WaitForBuildStepExecution_waitfor(step.getRunId())));
 
         String runHyperLink = ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName());
         TaskListener taskListener = getContext().get(TaskListener.class);

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/Messages.properties
@@ -28,7 +28,9 @@ BuildTriggerStep.no_job_configured=No job configured
 BuildTriggerStep.cannot_find=No such job {0}
 BuildTriggerStep.unsupported=Building a {0} is not supported
 BuildTriggerStepExecution.building_=Building {0}
+BuildTriggerStepExecution.scheduling_=Scheduling {0}
 BuildTriggerStepExecution.convertedParameterDescription=\
     {0} (Automatically converted to {1} because {2} passed the parameter using a different type)
 WaitForBuildStep.cannot_find=No such run with externalizable id {0}
 WaitForBuildStep.no_run_configured=No runId configured
+WaitForBuildStepExecution.waitfor_=Wait for {0} to complete

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/Messages.properties
@@ -28,9 +28,9 @@ BuildTriggerStep.no_job_configured=No job configured
 BuildTriggerStep.cannot_find=No such job {0}
 BuildTriggerStep.unsupported=Building a {0} is not supported
 BuildTriggerStepExecution.building_=Building {0}
-BuildTriggerStepExecution.scheduling_=Scheduling {0}
+BuildTriggerStepExecution.scheduling=Scheduling {0}
 BuildTriggerStepExecution.convertedParameterDescription=\
     {0} (Automatically converted to {1} because {2} passed the parameter using a different type)
 WaitForBuildStep.cannot_find=No such run with externalizable id {0}
 WaitForBuildStep.no_run_configured=No runId configured
-WaitForBuildStepExecution.waitfor_=Wait for {0} to complete
+WaitForBuildStepExecution.waitfor=Wait for {0} to complete


### PR DESCRIPTION
The label for the `build` step should differentiate between whether the step is waiting for the scheduled build to complete. Similarly the `waitForBuild` step label should reference the build it's waiting on.

![image](https://github.com/user-attachments/assets/715908e7-243e-4427-858b-5f590467f240)
![image](https://github.com/user-attachments/assets/ac5f5068-709f-405a-8800-a088164b7eb1)


### Testing done

Ran local pipelines that called `build` with a combination of `wait=true`, `wait=false` and `waitForStart=true` along with calling the `waitForBuild` step. Confirmed that labels associated with the step nodes was updated accordingly.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
